### PR TITLE
Feat : 차량 공유 서비스 등록, 내 서비스 조회, 내 서비스 참여자 조회 구현 / 차량 삭제 로직 수정

### DIFF
--- a/bururung/build.gradle
+++ b/bururung/build.gradle
@@ -58,6 +58,15 @@ dependencies {
     	implementation('org.springframework.boot:spring-boot-starter-websocket') {
     		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
     	}
+    	implementation('org.springframework.boot:spring-boot-starter-aop') {
+    		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
+    	}
+    	implementation('org.springframework.boot:spring-boot-starter-logging') {
+    		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
+    	}
+    	
+    	
+    	
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.3.1'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
 	compileOnly 'org.projectlombok:lombok'

--- a/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/controller/CarShareController.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/controller/CarShareController.java
@@ -1,18 +1,24 @@
 package com.hifive.bururung.domain.carshare.organizer.controller;
 
+
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.hifive.bururung.domain.carshare.organizer.dto.CarShareRegiRequestDTO;
+import com.hifive.bururung.domain.carshare.organizer.dto.MyCarServiceParticipantListResponseDTO;
 import com.hifive.bururung.domain.carshare.organizer.entity.CarShareRegistration;
 import com.hifive.bururung.domain.carshare.organizer.repository.CarRegistrationRepository;
 import com.hifive.bururung.domain.carshare.organizer.service.ICarShareService;
@@ -37,19 +43,19 @@ public class CarShareController {
             return ResponseEntity.badRequest().body("요청 데이터가 없습니다.");
         }
 
-        // ✅ 현재 로그인한 사용자 ID 가져오기
+        // 현재 로그인한 사용자 ID 가져오기
         Long memberId = Long.parseLong(authentication.getName());
 
-        // ✅ 차량 ID 조회
+        // 차량 ID 조회
         Long carId = carRegistrationRepository.findCarIdByMemberId(memberId);
         if (carId == null) {
             return ResponseEntity.badRequest().body("🚨 해당 회원의 차량 정보가 없습니다.");
         }
 
-        // ✅ pickupDate 변환 (프론트에서 "2025-02-14T06:00" 형식으로 보냄)
+        // pickupDate 변환 (프론트에서 "2025-02-14T06:00" 형식으로 보냄)
         LocalDateTime pickupDateTime = LocalDateTime.parse(request.getPickupDate(), DateTimeFormatter.ISO_LOCAL_DATE_TIME);
 
-        // ✅ DTO → 엔티티 변환 후 저장
+        // DTO → 엔티티 변환 후 저장
         CarShareRegistration savedCarShare = carShareService.registerCarShare(request, memberId, carId, pickupDateTime);
 
         return ResponseEntity.ok("차량 공유 서비스 등록 성공 (ID: " + savedCarShare.getCarShareRegiId() + ")");
@@ -57,7 +63,7 @@ public class CarShareController {
     
     @GetMapping("/my-list")
     public ResponseEntity<List<CarShareRegistration>> getMyCarShares(Authentication authentication) {
-        Long memberId = Long.parseLong(authentication.getName()); // 🔥 로그인한 사용자 ID
+        Long memberId = Long.parseLong(authentication.getName());
 
         List<CarShareRegistration> myCarShares = carShareService.getAllCarSharesByMemberId(memberId);
 
@@ -67,6 +73,32 @@ public class CarShareController {
 
         return ResponseEntity.ok(myCarShares);
     }
+
+    @GetMapping("/participants/{carShareRegiId}")
+    public ResponseEntity<List<MyCarServiceParticipantListResponseDTO>> getMyCarServiceParticipants(
+        @PathVariable("carShareRegiId") Long carShareRegiId
+    ){
+        System.out.println("🔍 요청된 carShareRegiId: " + carShareRegiId); // 로그 확인
+        List<MyCarServiceParticipantListResponseDTO> participants = carShareService.getMyCarShareServiceParticipantList(carShareRegiId);
+        System.out.println(participants);
+        return ResponseEntity.ok(participants);
+    }
+
+    
+    @PostMapping("/delete/{carShareRegiId}")
+    public ResponseEntity<String> deleteCarShare(@PathVariable("carShareRegiId") Long carShareRegiId, Authentication authentication){
+    	Long memberId = Long.parseLong(authentication.getName());
+    	Optional<CarShareRegistration> carShareOpt = carShareService.findById(carShareRegiId);
+        CarShareRegistration carShare = carShareOpt.get();
+        if (!carShare.getMemberId().equals(memberId)) {
+            return ResponseEntity.status(403).body("🚨 삭제 권한이 없습니다.");
+        }
+
+        carShareService.deleteCarShare(carShareRegiId);
+        return ResponseEntity.ok("✅ 차량 공유 서비스가 삭제되었습니다.");
+    }
+    
+    
 
 
 }

--- a/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/repository/CarShareRepository.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/repository/CarShareRepository.java
@@ -2,9 +2,14 @@ package com.hifive.bururung.domain.carshare.organizer.repository;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.hifive.bururung.domain.carshare.organizer.entity.CarShareRegistration;
+
+import jakarta.transaction.Transactional;
 
 public interface CarShareRepository extends JpaRepository<CarShareRegistration, Long>{
 	List<CarShareRegistration> findByMemberId(Long memberId);

--- a/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/service/CarShareService.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/service/CarShareService.java
@@ -2,11 +2,14 @@ package com.hifive.bururung.domain.carshare.organizer.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
 import com.hifive.bururung.domain.carshare.organizer.dto.CarShareRegiRequestDTO;
+import com.hifive.bururung.domain.carshare.organizer.dto.MyCarServiceParticipantListResponseDTO;
 import com.hifive.bururung.domain.carshare.organizer.entity.CarShareRegistration;
+import com.hifive.bururung.domain.carshare.organizer.repository.CarShareMapper;
 import com.hifive.bururung.domain.carshare.organizer.repository.CarShareRepository;
 
 import jakarta.transaction.Transactional;
@@ -14,11 +17,14 @@ import jakarta.transaction.Transactional;
 @Service
 public class CarShareService implements ICarShareService{
 	private final CarShareRepository carShareRepository;
+	private final CarShareMapper carShareMapper;
 	
-	public CarShareService (CarShareRepository carShareRepository) {
+	public CarShareService (CarShareRepository carShareRepository, CarShareMapper carShareMapper) {
 		this.carShareRepository = carShareRepository;
+		this.carShareMapper = carShareMapper;
 	}
 
+	// 차량 공유 서비스 등록
     @Transactional
     @Override
     public CarShareRegistration registerCarShare(CarShareRegiRequestDTO request, Long memberId, Long carId, LocalDateTime pickupDateTime) {
@@ -47,10 +53,31 @@ public class CarShareService implements ICarShareService{
         return carShareRepository.save(carShare);
     }
 
+    // 내 차량 공유 서비스 전체 조회
     @Override
     public List<CarShareRegistration> getAllCarSharesByMemberId(Long memberId) {
         return carShareRepository.findByMemberId(memberId);
     }
+    
+    
+    // 차량 공유 서비스 아이디로 공유 정보 조회
+    @Override
+    public Optional<CarShareRegistration> findById(Long carShareRegiId) {
+    	return carShareRepository.findById(carShareRegiId);
+    }
+    
+    // 차량 공유 서비스 삭제
+    @Transactional
+    @Override
+    public void deleteCarShare(Long carShareRegiId) {
+    	carShareRepository.deleteById(carShareRegiId);
+    }
+
+    // 내 차량 서비스 참가자 리스트 조회
+	@Override
+	public List<MyCarServiceParticipantListResponseDTO> getMyCarShareServiceParticipantList(Long carShareRegiId) {
+		return carShareMapper.findMyCarServiceParticipantList(carShareRegiId);
+	}
 
 
 }

--- a/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/service/ICarShareService.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/service/ICarShareService.java
@@ -2,8 +2,10 @@ package com.hifive.bururung.domain.carshare.organizer.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import com.hifive.bururung.domain.carshare.organizer.dto.CarShareRegiRequestDTO;
+import com.hifive.bururung.domain.carshare.organizer.dto.MyCarServiceParticipantListResponseDTO;
 import com.hifive.bururung.domain.carshare.organizer.entity.CarShareRegistration;
 
 public interface ICarShareService{
@@ -12,4 +14,13 @@ public interface ICarShareService{
 	
 	// 내가 등록한 차량 공유 서비스 전체 리스트 조회
 	List<CarShareRegistration> getAllCarSharesByMemberId(Long memberId);
+
+	// 차량 서비스 삭제 : 참여자 없을 때 만 가능함.
+	void deleteCarShare(Long carShareRegiId);
+
+	// 차량 공유 서비스 아이디로 찾기
+	Optional<CarShareRegistration> findById(Long id);
+	
+	// 내 차량 공유 서비스 참가자 리스트 조회
+	List<MyCarServiceParticipantListResponseDTO> getMyCarShareServiceParticipantList(Long carShareRegiId);
 }

--- a/bururung/src/main/java/com/hifive/bururung/global/config/SecurityConfig.java
+++ b/bururung/src/main/java/com/hifive/bururung/global/config/SecurityConfig.java
@@ -52,6 +52,8 @@ public class SecurityConfig {
                                 .requestMatchers("/api/admin/**").hasRole("OPERATOR")
                                 .requestMatchers("/api/statistics/**").hasRole("OPERATOR")
                                 .requestMatchers("/api/notifications/**").authenticated()
+                                .requestMatchers("/api/car-share/participants/**").permitAll()
+
                                 .anyRequest().authenticated()
 //                      .requestMatchers("/**").permitAll()
 

--- a/bururung/src/main/java/com/hifive/bururung/global/config/SecurityConfig.java
+++ b/bururung/src/main/java/com/hifive/bururung/global/config/SecurityConfig.java
@@ -32,19 +32,7 @@ public class SecurityConfig {
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
-<<<<<<< HEAD
-//                                .requestMatchers("/api/member/login").permitAll()
-//                                .requestMatchers("/api/member/signup").permitAll()
-//                                .requestMatchers("/api/email/**").permitAll()
-//                                .requestMatchers("/api/member/find-email").permitAll()
-//                                .requestMatchers("/api/member/change-password").permitAll()
-//                                .requestMatchers("/api/car-registration/**").authenticated() // 차량 등록 API는 인증 필요
-//                                .requestMatchers("/error").permitAll()
-//                                .requestMatchers("/api/carshare/registration/available-list").permitAll()
-//
-//                                .anyRequest().authenticated()
-                		.requestMatchers("/**").permitAll()
-=======
+
                                 .requestMatchers("/api/member/login").permitAll()
                                 .requestMatchers("/api/member/signup").permitAll()
                                 .requestMatchers("/api/member/logout").permitAll()
@@ -64,10 +52,9 @@ public class SecurityConfig {
                                 .requestMatchers("/api/admin/**").hasRole("OPERATOR")
                                 .requestMatchers("/api/statistics/**").hasRole("OPERATOR")
                                 .requestMatchers("/api/notifications/**").authenticated()
-
                                 .anyRequest().authenticated()
 //                      .requestMatchers("/**").permitAll()
->>>>>>> f8fe8e45b820cd0b022741f204bfa82b66332d32
+
                 )
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/bururung/src/main/java/com/hifive/bururung/global/config/WebMvcConfig.java
+++ b/bururung/src/main/java/com/hifive/bururung/global/config/WebMvcConfig.java
@@ -3,6 +3,7 @@ package com.hifive.bururung.global.config;
 //import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -11,6 +12,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import jakarta.servlet.Filter;
 
+@EnableAspectJAutoProxy
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 

--- a/bururung/src/main/resources/mapper/carshare/participant/CarshareRegistrationMapper.xml
+++ b/bururung/src/main/resources/mapper/carshare/participant/CarshareRegistrationMapper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE mapper SYSTEM "file:///C:/dev/workspace/finalmeta/backend/hiapp/src/main/resources/mybatis-3-mapper.dtd">
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.hifive.bururung.domain.carshare.participant.repository.ServiceRegistrationRepository">
 	
@@ -8,7 +8,7 @@
 		SELECT DISTINCT m.member_id, csr.car_share_regi_id, m.nickname, csr.latitude_pl, csr.longitude_pl, csr.latitude_ds, csr.longitude_ds, TO_CHAR(csr.pickup_date, 'YYYY-MM-DD HH24:MI:SS') AS pickup_date
 		FROM CAR_SHARE_REGISTRATION csr
     		LEFT JOIN CAR_SHARE_JOIN csj
-        		ON csr.car_share_regi_id = csj.car_share_regi_id
+        		ON csr.car_share_ regi_id = csj.car_share_regi_id
     		RIGHT JOIN MEMBER m
         		ON csr.member_id = m.member_id
 		WHERE csr.pickup_date > LOCALTIMESTAMP


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[V] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/car-share/register -> develop

### 변경 사항
- 차량 공유 서비스 CRUD 구현
- 차량 삭제 시 공유 서비스 존재 여부 확인 후 있는 경우 해당 CAR_ID를 삭제된 차량으로 '0'으로 업데이트 처리 후 삭제

### 테스트 결과
- 차량 공유 서비스 등록이 가능하다
- 내 차량 공유 서비스 참가자 조회 가능 : 해당 회원의 닉네임과 별점, 후기, 참여 일시 확인 가능