### PR TITLE
Feat: 커버리지 측정 도구 jacoco 추가, excel 다운로드 기능 추가

### DIFF
--- a/bururung/build.gradle
+++ b/bururung/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'war'
 	id 'org.springframework.boot' version '3.4.2'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'com.hifive'
@@ -26,6 +27,30 @@ configurations {
 
 repositories {
 	mavenCentral()
+}
+
+jacoco {
+    toolVersion = "0.8.10" // 사용 가능한 최신 버전 확인
+}
+
+test {
+    finalizedBy jacocoTestReport // 테스트 후 리포트 자동 생성
+}
+
+jacocoTestReport {
+    reports {
+        html.required = true
+        xml.required = true
+        csv.required = true
+    }
+    // 특정 패키지나 클래스 제외 설정 예시
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect { fileTree(dir: it, exclude: [
+            '**/global/**',
+            '**/dto/**',
+            '**/entity/**'
+        ]) }))
+    }
 }
 
 dependencies {
@@ -81,6 +106,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	compileOnly 'net.minidev:json-smart:2.0'
+	implementation 'org.apache.poi:poi-ooxml:5.2.3'
 }
 
 

--- a/bururung/src/main/java/com/hifive/bururung/domain/admin/controller/AdminController.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/admin/controller/AdminController.java
@@ -1,12 +1,19 @@
 package com.hifive.bururung.domain.admin.controller;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -113,4 +120,60 @@ public class AdminController {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
 		}
 	}
+	
+	@GetMapping("/excel")
+    public ResponseEntity<byte[]> downloadExcel() {
+    	try {
+    		// 1. 결제 데이터를 서비스로부터 가져오기
+    		List<AdminPaymentDTO> paymentList = adminService.getPaymentList();
+    		System.out.println(paymentList);
+    		
+    		// 2. Excel 워크북 및 시트 생성
+    		Workbook workbook = new XSSFWorkbook();
+    		Sheet sheet = workbook.createSheet("Payments");
+    		
+    		// 3. 헤더 행 생성
+    		Row header = sheet.createRow(0);
+    		header.createCell(0).setCellValue("Payment ID");
+    		header.createCell(1).setCellValue("Order Id");
+    		header.createCell(2).setCellValue("Price");
+    		header.createCell(3).setCellValue("Member Id");
+    		header.createCell(4).setCellValue("Credit Id");
+    		header.createCell(5).setCellValue("Method");
+    		header.createCell(6).setCellValue("Payment Date");
+    		header.createCell(7).setCellValue("Approve Date");
+    		
+    		// 4. 결제 데이터 리스트를 순회하며 행 생성
+    		int rowNum = 1;
+    		for (AdminPaymentDTO payment : paymentList) {
+    			Row row = sheet.createRow(rowNum++);
+    			row.createCell(0).setCellValue(payment.getPaymentId());
+    			row.createCell(1).setCellValue(payment.getOrderId());
+    			row.createCell(2).setCellValue(payment.getPrice());
+    			row.createCell(3).setCellValue(payment.getMemberId());
+    			row.createCell(4).setCellValue(payment.getCreditId());
+    			row.createCell(5).setCellValue(payment.getMethod());
+    			row.createCell(6).setCellValue(payment.getCreatedDate());
+    			row.createCell(7).setCellValue(payment.getApprovedDate());
+    		}
+    		
+    		// 5. 워크북을 byte 배열로 변환
+    		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    		workbook.write(bos);
+    		workbook.close();
+    		byte[] excelBytes = bos.toByteArray();
+    		
+    		// 6. 응답 헤더 설정 (attachment로 다운로드)
+    		HttpHeaders headers = new HttpHeaders();
+    		headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+    		ContentDisposition contentDisposition = ContentDisposition
+    				.attachment()
+    				.filename("payments.xlsx")
+    				.build();
+    		headers.setContentDisposition(contentDisposition);
+    		return new ResponseEntity<>(excelBytes, headers, HttpStatus.OK);			
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage().getBytes());
+		}
+    }
 }

--- a/bururung/src/main/java/com/hifive/bururung/domain/admin/dto/AdminPaymentDTO.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/admin/dto/AdminPaymentDTO.java
@@ -1,5 +1,7 @@
 package com.hifive.bururung.domain.admin.dto;
 
+import java.sql.Timestamp;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,8 +11,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AdminPaymentDTO {
 	private Long paymentId;
-	private String createdDate;
-	private String approvedDate;
+	private Timestamp createdDate;
+	private Timestamp approvedDate;
 	private String method;
 	private String orderId;
 	private Long price;

--- a/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/dto/CarShareRegiRequestDTO.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/dto/CarShareRegiRequestDTO.java
@@ -2,9 +2,8 @@ package com.hifive.bururung.domain.carshare.organizer.dto;
 
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
-@Getter @Setter @ToString
+@Getter @Setter
 public class CarShareRegiRequestDTO {
     private String pickupLoc;
     private double latitudePl;
@@ -24,7 +23,6 @@ public class CarShareRegiRequestDTO {
     private String pickupDate;
     private String category;
     
-    @Override
     public String toString() {
         return "CarShareRegiRequestDTO{" +
                 "pickupLoc='" + pickupLoc + '\'' +

--- a/bururung/src/test/java/com/hifive/bururung/domain/admin/controller/AdminControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/admin/controller/AdminControllerTest.java
@@ -1,0 +1,144 @@
+package com.hifive.bururung.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.hifive.bururung.domain.admin.dto.AdminCarRegistrationDTO;
+import com.hifive.bururung.domain.admin.dto.AdminCarRegistrationRequest;
+import com.hifive.bururung.domain.admin.dto.AdminCarRegistrationResponse;
+import com.hifive.bururung.domain.admin.dto.AdminCarShareDTO;
+import com.hifive.bururung.domain.admin.dto.AdminCarShareResponse;
+import com.hifive.bururung.domain.admin.dto.AdminMemberDTO;
+import com.hifive.bururung.domain.admin.dto.AdminMemberResponse;
+import com.hifive.bururung.domain.admin.dto.AdminPaymentDTO;
+import com.hifive.bururung.domain.admin.dto.AdminPaymentResponse;
+import com.hifive.bururung.domain.admin.dto.AdminTaxiShareDTO;
+import com.hifive.bururung.domain.admin.dto.AdminTaxiShareResponse;
+import com.hifive.bururung.domain.admin.service.IAdminService;
+import com.hifive.bururung.domain.notification.entity.Notification;
+import com.hifive.bururung.domain.notification.service.INotificationService;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminControllerTest {
+
+    @InjectMocks
+    private AdminController adminController;
+    
+    @Mock
+    private IAdminService adminService;
+    
+    @Mock
+    private INotificationService notificationService;
+    
+    @Test
+    public void testGetMemberList_success() {
+        // 더미 데이터 생성
+        List<AdminMemberDTO> memberList = Arrays.asList(new AdminMemberDTO(), new AdminMemberDTO());
+        when(adminService.getMemberList()).thenReturn(memberList);
+        
+        // 직접 메서드 호출
+        ResponseEntity<AdminMemberResponse<List<AdminMemberDTO>>> responseEntity = adminController.getMemberList();
+        AdminMemberResponse<List<AdminMemberDTO>> response = responseEntity.getBody();
+        
+        // 응답 검증
+        assertNotNull(response);
+        assertTrue(response.isStatus());
+        assertEquals(memberList.size(), response.getData().size());
+    }
+    
+    @Test
+    public void testGetRegistrationList_success() {
+        List<AdminCarRegistrationDTO> registrationList = Arrays.asList(new AdminCarRegistrationDTO());
+        when(adminService.getRegistrationList()).thenReturn(registrationList);
+        
+        ResponseEntity<AdminCarRegistrationResponse<List<AdminCarRegistrationDTO>>> responseEntity = adminController.getRegistrationList();
+        AdminCarRegistrationResponse<List<AdminCarRegistrationDTO>> response = responseEntity.getBody();
+        
+        assertNotNull(response);
+        assertTrue(response.isSuccess());
+        assertEquals(registrationList.size(), response.getData().size());
+    }
+    
+    @Test
+    public void testGetTaxiShareServiceList_success() {
+        List<AdminTaxiShareDTO> taxiShareList = Arrays.asList(new AdminTaxiShareDTO());
+        when(adminService.getTaxiShareServiceList()).thenReturn(taxiShareList);
+        
+        ResponseEntity<AdminTaxiShareResponse<List<AdminTaxiShareDTO>>> responseEntity = adminController.getTaxiShareServiceList();
+        AdminTaxiShareResponse<List<AdminTaxiShareDTO>> response = responseEntity.getBody();
+        
+        assertNotNull(response);
+        assertTrue(response.isSuccess());
+        assertEquals(taxiShareList.size(), response.getData().size());
+    }
+    
+    @Test
+    public void testGetCarShareServiceList_success() {
+        List<AdminCarShareDTO> carShareList = Arrays.asList(new AdminCarShareDTO());
+        when(adminService.getCarShareServiceList()).thenReturn(carShareList);
+        
+        ResponseEntity<AdminCarShareResponse<List<AdminCarShareDTO>>> responseEntity = adminController.getCarShareServiceList();
+        AdminCarShareResponse<List<AdminCarShareDTO>> response = responseEntity.getBody();
+        
+        assertNotNull(response);
+        assertTrue(response.isSuccess());
+        assertEquals(carShareList.size(), response.getData().size());
+    }
+    
+    @Test
+    public void testGetPaymentList_success() {
+        List<AdminPaymentDTO> paymentList = Arrays.asList(new AdminPaymentDTO());
+        when(adminService.getPaymentList()).thenReturn(paymentList);
+        
+        ResponseEntity<AdminPaymentResponse<List<AdminPaymentDTO>>> responseEntity = adminController.getPaymentList();
+        AdminPaymentResponse<List<AdminPaymentDTO>> response = responseEntity.getBody();
+        
+        assertNotNull(response);
+        assertTrue(response.isSuccess());
+        assertEquals(paymentList.size(), response.getData().size());
+    }
+    
+    @Test
+    public void testApproveRegistration_success() {
+        AdminCarRegistrationRequest request = new AdminCarRegistrationRequest();
+        // 필요한 경우 request 필드 설정
+        
+        // adminService.approveRegistration 호출 시 아무런 예외 없이 실행됨을 가정
+        doNothing().when(adminService).approveRegistration(any(AdminCarRegistrationRequest.class));
+        
+        ResponseEntity<String> responseEntity = adminController.approveRegistration(request);
+        
+        assertEquals("ok", responseEntity.getBody());
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    }
+    
+    @Test
+    public void testRequestUpdateRegistration_success() {
+        AdminCarRegistrationRequest request = new AdminCarRegistrationRequest();
+        request.setCarId(1L);
+        request.setMemberId(2L);
+        
+        // deleteRegistration, sendNotification 호출 시 예외 없이 동작하도록 설정
+        doNothing().when(adminService).deleteRegistration(anyLong());
+        doNothing().when(notificationService).sendNotification(any(Notification.class));
+        
+        ResponseEntity<String> responseEntity = adminController.requestUpdateRegistration(request);
+        
+        assertEquals("ok", responseEntity.getBody());
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/admin/service/AdminServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/admin/service/AdminServiceTest.java
@@ -1,0 +1,132 @@
+package com.hifive.bururung.domain.admin.service;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.admin.dto.AdminCarRegistrationDTO;
+import com.hifive.bururung.domain.admin.dto.AdminCarRegistrationRequest;
+import com.hifive.bururung.domain.admin.dto.AdminCarShareDTO;
+import com.hifive.bururung.domain.admin.dto.AdminMemberDTO;
+import com.hifive.bururung.domain.admin.dto.AdminPaymentDTO;
+import com.hifive.bururung.domain.admin.dto.AdminTaxiShareDTO;
+import com.hifive.bururung.domain.admin.repository.IAdminMapper;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminServiceTest {
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Mock
+    private IAdminMapper adminMapper;
+
+    @Test
+    public void testGetMemberList() {
+        // given
+        List<AdminMemberDTO> expectedList = new ArrayList<>();
+        when(adminMapper.getMemberList()).thenReturn(expectedList);
+
+        // when
+        List<AdminMemberDTO> actualList = adminService.getMemberList();
+
+        // then
+        assertSame(expectedList, actualList);
+        verify(adminMapper).getMemberList();
+    }
+
+    @Test
+    public void testGetRegistrationList() {
+        // given
+        List<AdminCarRegistrationDTO> expectedList = new ArrayList<>();
+        when(adminMapper.getRegistrationList()).thenReturn(expectedList);
+
+        // when
+        List<AdminCarRegistrationDTO> actualList = adminService.getRegistrationList();
+
+        // then
+        assertSame(expectedList, actualList);
+        verify(adminMapper).getRegistrationList();
+    }
+
+    @Test
+    public void testGetTaxiShareServiceList() {
+        // given
+        List<AdminTaxiShareDTO> expectedList = new ArrayList<>();
+        when(adminMapper.getTaxiShareServiceList()).thenReturn(expectedList);
+
+        // when
+        List<AdminTaxiShareDTO> actualList = adminService.getTaxiShareServiceList();
+
+        // then
+        assertSame(expectedList, actualList);
+        verify(adminMapper).getTaxiShareServiceList();
+    }
+
+    @Test
+    public void testGetCarShareServiceList() {
+        // given
+        List<AdminCarShareDTO> expectedList = new ArrayList<>();
+        when(adminMapper.getCarShareServiceList()).thenReturn(expectedList);
+
+        // when
+        List<AdminCarShareDTO> actualList = adminService.getCarShareServiceList();
+
+        // then
+        assertSame(expectedList, actualList);
+        verify(adminMapper).getCarShareServiceList();
+    }
+
+    @Test
+    public void testGetPaymentList() {
+        // given
+        List<AdminPaymentDTO> expectedList = new ArrayList<>();
+        when(adminMapper.getPaymentList()).thenReturn(expectedList);
+
+        // when
+        List<AdminPaymentDTO> actualList = adminService.getPaymentList();
+
+        // then
+        assertSame(expectedList, actualList);
+        verify(adminMapper).getPaymentList();
+    }
+
+    @Test
+    public void testApproveRegistration() {
+        // given
+        AdminCarRegistrationRequest registrationRequest = new AdminCarRegistrationRequest();
+        Long dummyCarId = 123L;
+        Long dummyMemberId = 456L;
+        // registrationRequest에 carId와 memberId를 설정 (setter가 있다고 가정)
+        registrationRequest.setCarId(dummyCarId);
+        registrationRequest.setMemberId(dummyMemberId);
+
+        // when
+        adminService.approveRegistration(registrationRequest);
+
+        // then
+        verify(adminMapper).updateRegistrationSetVerifiedToY(dummyCarId);
+        verify(adminMapper).updateMemberToDriver(dummyMemberId);
+    }
+
+    @Test
+    public void testDeleteRegistration() {
+        // given
+        Long carId = 789L;
+
+        // when
+        adminService.deleteRegistration(carId);
+
+        // then
+        verify(adminMapper).deleteRegistration(carId);
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/carshare/organizer/controller/CarRegistrationControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/carshare/organizer/controller/CarRegistrationControllerTest.java
@@ -1,0 +1,419 @@
+package com.hifive.bururung.domain.carshare.organizer.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.hifive.bururung.domain.carshare.organizer.dto.CarUpdateRequestDTO;
+import com.hifive.bururung.domain.carshare.organizer.dto.CarUpdateResponseDTO;
+import com.hifive.bururung.domain.carshare.organizer.entity.CarRegistration;
+import com.hifive.bururung.domain.carshare.organizer.service.ICarRegistrationService;
+import com.hifive.bururung.domain.member.entity.Member;
+import com.hifive.bururung.domain.member.service.MemberService;
+import com.hifive.bururung.global.common.s3.FileSubPath;
+import com.hifive.bururung.global.common.s3.S3Uploader;
+import com.hifive.bururung.global.common.s3.UploadFileDTO;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.CarRegistrationErrorCode;
+import com.hifive.bururung.global.util.SecurityUtil;
+
+@ExtendWith(MockitoExtension.class)
+public class CarRegistrationControllerTest {
+
+    @InjectMocks
+    private CarRegistrationController controller;
+    
+    @Mock
+    private ICarRegistrationService carRegistrationService;
+    
+    @Mock
+    private MemberService memberService;
+    
+    @Mock
+    private S3Uploader s3Uploader;
+    
+    @BeforeEach
+    void setUp() {
+        // 특별한 설정이 없다면 이곳에 작성
+    }
+    
+    // 1. POST /api/car-registration/upload-car-image
+    @Test
+    void testUploadCarImage_NullFile() throws IOException {
+        ResponseEntity<String> response = controller.uploadCarImage(null);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("🚨 업로드할 파일이 없습니다! (NULL)", response.getBody());
+    }
+    
+    @Test
+    void testUploadCarImage_EmptyFile() throws IOException {
+        MultipartFile emptyFile = new MockMultipartFile("carImage", "empty.jpg", "image/jpeg", new byte[0]);
+        ResponseEntity<String> response = controller.uploadCarImage(emptyFile);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("🚨 업로드할 파일이 없습니다! (EMPTY)", response.getBody());
+    }
+    
+    @Test
+    void testUploadCarImage_Success() throws IOException {
+        MultipartFile file = new MockMultipartFile("carImage", "test.jpg", "image/jpeg", "dummy".getBytes());
+        UploadFileDTO uploadDTO = mock(UploadFileDTO.class);
+        when(uploadDTO.getStoreFullUrl()).thenReturn("http://s3.example.com/test.jpg");
+        when(s3Uploader.uploadFile(file, FileSubPath.CAR.getPath())).thenReturn(uploadDTO);
+        
+        ResponseEntity<String> response = controller.uploadCarImage(file);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("http://s3.example.com/test.jpg", response.getBody());
+    }
+    
+    // 2. POST /api/car-registration/upload-verified-file
+    @Test
+    void testUploadAgreementFile_Success() throws IOException {
+        MultipartFile file = new MockMultipartFile("agreementFile", "agreement.pdf", "application/pdf", "dummy".getBytes());
+        UploadFileDTO uploadDTO = mock(UploadFileDTO.class);
+        when(uploadDTO.getStoreFullUrl()).thenReturn("http://s3.example.com/agreement.pdf");
+        when(s3Uploader.uploadFile(file, FileSubPath.VERIFIED.getPath())).thenReturn(uploadDTO);
+        
+        ResponseEntity<String> response = controller.uploadAgreementFile(file);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("http://s3.example.com/agreement.pdf", response.getBody());
+    }
+    
+    // 3. POST /api/car-registration/register
+    @Test
+    void testRegisterCar_Success() {
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            secMock.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+            
+            // Duplicate checks return false
+            when(carRegistrationService.isCarAlreadyRegistered(1L)).thenReturn(false);
+            when(carRegistrationService.isCarNumberExists("ABC123")).thenReturn(false);
+            
+            // Stub memberService.findByMemberId
+            Member member = mock(Member.class);
+            when(memberService.findByMemberId(1L)).thenReturn(member);
+            
+            // Stub registerCar() to do nothing
+            doNothing().when(carRegistrationService).registerCar(any(CarRegistration.class));
+            
+            ResponseEntity<String> response = controller.registerCar(
+                "http://s3.example.com/car.jpg",
+                "http://s3.example.com/agreement.pdf",
+                " ABC 123 ",
+                "ModelX",
+                4,
+                "Red",
+                "Nice car"
+            );
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertEquals("차량이 성공적으로 등록되었습니다.", response.getBody());
+            
+            // Verify that car number was cleaned (i.e., spaces removed)
+            ArgumentCaptor<CarRegistration> captor = ArgumentCaptor.forClass(CarRegistration.class);
+            verify(carRegistrationService).registerCar(captor.capture());
+            CarRegistration savedCar = captor.getValue();
+            assertEquals("ABC123", savedCar.getCarNumber());
+            assertEquals("ModelX", savedCar.getCarModel());
+            assertEquals(4, savedCar.getMaxPassengers());
+            assertEquals("Red", savedCar.getColor());
+            assertEquals("Nice car", savedCar.getCarDescription());
+        }
+    }
+    
+    @Test
+    void testRegisterCar_Unauthorized() {
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            String errorMsg = "Unauthorized access";
+            secMock.when(SecurityUtil::getCurrentMemberId).thenThrow(new IllegalArgumentException(errorMsg));
+            
+            ResponseEntity<String> response = controller.registerCar(
+                "url", "agreement", "123", "model", 4, "color", "desc"
+            );
+            assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+            assertEquals(errorMsg, response.getBody());
+        }
+    }
+    
+    @Test
+    void testRegisterCar_DuplicateRegistration() {
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            secMock.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+            when(carRegistrationService.isCarAlreadyRegistered(1L)).thenReturn(true);
+            
+            CustomException ex = assertThrows(CustomException.class, () ->
+                controller.registerCar("url", "agreement", "123", "model", 4, "color", "desc")
+            );
+            assertEquals(CarRegistrationErrorCode.CAR_ALREADY_REGISTERED, ex.getErrorCode());
+        }
+    }
+    
+    @Test
+    void testRegisterCar_DuplicateCarNumber() {
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            secMock.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+            when(carRegistrationService.isCarAlreadyRegistered(1L)).thenReturn(false);
+            when(carRegistrationService.isCarNumberExists("ABC123")).thenReturn(true);
+            
+            CustomException ex = assertThrows(CustomException.class, () ->
+                controller.registerCar("url", "agreement", " ABC 123 ", "model", 4, "color", "desc")
+            );
+            assertEquals(CarRegistrationErrorCode.DUPLICATE_CAR_NUMBER, ex.getErrorCode());
+        }
+    }
+    
+    // 4. GET /api/car-registration/list
+    @Test
+    void testGetAllCars() {
+        List<CarRegistration> carList = mock(List.class);
+        when(carRegistrationService.getAllCars()).thenReturn(carList);
+        
+        ResponseEntity<List<CarRegistration>> response = controller.getAllCars();
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(carList, response.getBody());
+    }
+    
+    // 5. GET /api/car-registration/car/by-number/{carNumber}
+    @Test
+    void testGetCarByCarNumber_Found() {
+        String carNumber = "ABC123";
+        CarRegistration car = mock(CarRegistration.class);
+        when(carRegistrationService.getCarByCarNumber(carNumber)).thenReturn(Optional.of(car));
+        
+        ResponseEntity<CarRegistration> response = controller.getCarByCarNimber(carNumber);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(car, response.getBody());
+    }
+    
+    @Test
+    void testGetCarByCarNumber_NotFound() {
+        String carNumber = "XYZ789";
+        when(carRegistrationService.getCarByCarNumber(carNumber)).thenReturn(Optional.empty());
+        
+        ResponseEntity<CarRegistration> response = controller.getCarByCarNimber(carNumber);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+    
+    // 6. GET /api/car-registration/car/by-id/{carId}
+    @Test
+    void testGetCarByCarId_Success() {
+        Long carId = 10L;
+        CarRegistration car = mock(CarRegistration.class);
+        when(carRegistrationService.getCarByCarId(carId)).thenReturn(Optional.of(car));
+        
+        ResponseEntity<CarRegistration> response = controller.getCarByCarId(carId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(car, response.getBody());
+    }
+    
+    @Test
+    void testGetCarByCarId_NotFound() {
+        Long carId = 10L;
+        when(carRegistrationService.getCarByCarId(carId)).thenReturn(Optional.empty());
+        
+        CustomException ex = assertThrows(CustomException.class, () ->
+            controller.getCarByCarId(carId)
+        );
+        assertEquals(CarRegistrationErrorCode.CAR_NOT_FOUND, ex.getErrorCode());
+    }
+    
+    // 7. GET /api/car-registration/verified/{memberId}
+    @Test
+    void testIsCarVerified_Success() {
+        Long memberId = 1L;
+        when(carRegistrationService.isCarAlreadyRegistered(memberId)).thenReturn(true);
+        when(carRegistrationService.isVerified(memberId)).thenReturn(true);
+        
+        ResponseEntity<Boolean> response = controller.isCarVerified(memberId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody());
+    }
+    
+    @Test
+    void testIsCarVerified_NotRegistered() {
+        Long memberId = 1L;
+        when(carRegistrationService.isCarAlreadyRegistered(memberId)).thenReturn(false);
+        
+        CustomException ex = assertThrows(CustomException.class, () ->
+            controller.isCarVerified(memberId)
+        );
+        assertEquals(CarRegistrationErrorCode.CAR_NOT_FOUND, ex.getErrorCode());
+    }
+    
+    // 8. GET /api/car-registration/member/{memberId}
+    @Test
+    void testGetCarByMemberId_Success() {
+        Long memberId = 1L;
+        CarRegistration car = mock(CarRegistration.class);
+        when(carRegistrationService.getCarByMemberId(memberId)).thenReturn(Optional.of(car));
+        
+        // Static mock for SecurityUtil.getCurrentMemberId()
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            secMock.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+            // CarRegistrationResponseDTO 생성은 내부 로직에 의존하므로, 반환 객체가 null이 아님을 검증
+            ResponseEntity<?> response = controller.getCarByMemberId(memberId);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+        }
+    }
+    
+    @Test
+    void testGetCarByMemberId_NotFound() {
+        Long memberId = 1L;
+        when(carRegistrationService.getCarByMemberId(memberId)).thenReturn(Optional.empty());
+        
+        CustomException ex = assertThrows(CustomException.class, () ->
+            controller.getCarByMemberId(memberId)
+        );
+        assertEquals(CarRegistrationErrorCode.CAR_NOT_FOUND, ex.getErrorCode());
+    }
+    
+    // 9. PUT /api/car-registration/update/{carId}
+    @Test
+    void testUpdateCar_Success() {
+        Long carId = 10L;
+        // Mock existing CarRegistration and CarUpdateRequestDTO
+        CarRegistration car = mock(CarRegistration.class);
+        Member member = mock(Member.class);
+        when(member.getMemberId()).thenReturn(1L);
+        when(car.getMember()).thenReturn(member);
+        when(carRegistrationService.getCarByCarId(carId)).thenReturn(Optional.of(car));
+        
+        CarUpdateRequestDTO updateRequest = mock(CarUpdateRequestDTO.class);
+        when(updateRequest.getCarNumber()).thenReturn(" XYZ 789 ");
+        when(updateRequest.getCarModel()).thenReturn("ModelY");
+        when(updateRequest.getMaxPassengers()).thenReturn(5);
+        when(updateRequest.getColor()).thenReturn("Blue");
+        when(updateRequest.getImageUrl()).thenReturn("http://s3.example.com/newcar.jpg");
+        when(updateRequest.getImageName()).thenReturn("NewCarImage");
+        when(updateRequest.getVerifiedFile()).thenReturn("http://s3.example.com/newagreement.pdf");
+        when(updateRequest.getCarDescription()).thenReturn("Updated description");
+        
+        CarRegistration updatedCar = mock(CarRegistration.class);
+        when(carRegistrationService.updateCar(car)).thenReturn(updatedCar);
+        
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            secMock.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+            
+            ResponseEntity<CarUpdateResponseDTO> response = (ResponseEntity<CarUpdateResponseDTO>) controller.updateCar(carId, updateRequest);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            
+            // Verify that cleanCarNumber() was applied.
+            ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+            verify(car).setCarNumber(captor.capture());
+            assertEquals("XYZ789", captor.getValue());
+        }
+    }
+    
+    @Test
+    void testUpdateCar_Unauthorized() {
+        Long carId = 10L;
+        CarUpdateRequestDTO updateRequest = mock(CarUpdateRequestDTO.class);
+        
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            String errorMsg = "Unauthorized";
+            secMock.when(SecurityUtil::getCurrentMemberId).thenThrow(new IllegalArgumentException(errorMsg));
+            
+            ResponseEntity<?> response = controller.updateCar(carId, updateRequest);
+            assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+            assertEquals(errorMsg, response.getBody());
+        }
+    }
+    
+    @Test
+    void testUpdateCar_CarNotFound() {
+        Long carId = 10L;
+        CarUpdateRequestDTO updateRequest = mock(CarUpdateRequestDTO.class);
+        when(carRegistrationService.getCarByCarId(carId)).thenReturn(Optional.empty());
+        
+        CustomException ex = assertThrows(CustomException.class, () ->
+            controller.updateCar(carId, updateRequest)
+        );
+        assertEquals(CarRegistrationErrorCode.CAR_NOT_FOUND, ex.getErrorCode());
+    }
+    
+    @Test
+    void testUpdateCar_RoleNotModify() {
+        Long carId = 10L;
+        CarRegistration car = mock(CarRegistration.class);
+        Member member = mock(Member.class);
+        // Session member is 1L, but car's member is 2L
+        when(member.getMemberId()).thenReturn(2L);
+        when(car.getMember()).thenReturn(member);
+        when(carRegistrationService.getCarByCarId(carId)).thenReturn(Optional.of(car));
+        
+        CarUpdateRequestDTO updateRequest = mock(CarUpdateRequestDTO.class);
+        
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            secMock.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+            
+            CustomException ex = assertThrows(CustomException.class, () ->
+                controller.updateCar(carId, updateRequest)
+            );
+            assertEquals(CarRegistrationErrorCode.ROLE_NOT_MODIFY, ex.getErrorCode());
+        }
+    }
+    
+    // 10. DELETE /api/car-registration/delete/{carId}
+    @Test
+    void testDeleteCar_Success() {
+        Long carId = 20L;
+        CarRegistration car = mock(CarRegistration.class);
+        Member member = mock(Member.class);
+        when(member.getMemberId()).thenReturn(1L);
+        when(car.getMember()).thenReturn(member);
+        when(carRegistrationService.getCarByCarId(carId)).thenReturn(Optional.of(car));
+        
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            secMock.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+            ResponseEntity<String> response = controller.deleteCar(carId);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertEquals("차량이 성공적으로 삭제되었습니다.", response.getBody());
+            verify(carRegistrationService).deleteCar(carId);
+        }
+    }
+    
+    @Test
+    void testDeleteCar_RoleNotDelete() {
+        Long carId = 20L;
+        CarRegistration car = mock(CarRegistration.class);
+        Member member = mock(Member.class);
+        // Session member is 1L, but car's member is 2L
+        when(member.getMemberId()).thenReturn(2L);
+        when(car.getMember()).thenReturn(member);
+        when(carRegistrationService.getCarByCarId(carId)).thenReturn(Optional.of(car));
+        
+        try (MockedStatic<SecurityUtil> secMock = mockStatic(SecurityUtil.class)) {
+            secMock.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+            CustomException ex = assertThrows(CustomException.class, () ->
+                controller.deleteCar(carId)
+            );
+            assertEquals(CarRegistrationErrorCode.ROLE_NOT_DELETE, ex.getErrorCode());
+        }
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/carshare/organizer/controller/CarShareControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/carshare/organizer/controller/CarShareControllerTest.java
@@ -1,0 +1,135 @@
+package com.hifive.bururung.domain.carshare.organizer.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import com.hifive.bururung.domain.carshare.organizer.dto.CarShareRegiRequestDTO;
+import com.hifive.bururung.domain.carshare.organizer.entity.CarShareRegistration;
+import com.hifive.bururung.domain.carshare.organizer.repository.CarRegistrationRepository;
+import com.hifive.bururung.domain.carshare.organizer.service.ICarShareService;
+
+@ExtendWith(MockitoExtension.class)
+public class CarShareControllerTest {
+
+    @InjectMocks
+    private CarShareController controller;
+
+    @Mock
+    private ICarShareService carShareService;
+
+    @Mock
+    private CarRegistrationRepository carRegistrationRepository;
+    
+    @Mock
+    private Authentication authentication;
+
+    // ──────────────── registerCarShare ────────────────
+
+    // 1. 요청 데이터가 null인 경우
+    @Test
+    void testRegisterCarShare_NullRequest() throws Exception {
+        ResponseEntity<String> response = controller.registerCarShare(null, authentication);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("요청 데이터가 없습니다.", response.getBody());
+    }
+
+    // 2. 로그인한 회원의 차량 정보가 없는 경우 (repository가 null을 반환)
+    @Test
+    void testRegisterCarShare_NoCarFound() throws Exception {
+        // 준비: 유효한 요청 DTO 생성
+        CarShareRegiRequestDTO request = new CarShareRegiRequestDTO();
+        request.setPickupDate("2025-02-14T06:00");
+
+        // Authentication에서 회원 ID를 "1"로 반환하도록 설정
+        when(authentication.getName()).thenReturn("1");
+        // repository에서 차량 ID가 없음을 의미하도록 null 반환
+        when(carRegistrationRepository.findCarIdByMemberId(1L)).thenReturn(null);
+
+        ResponseEntity<String> response = controller.registerCarShare(request, authentication);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("🚨 해당 회원의 차량 정보가 없습니다.", response.getBody());
+    }
+
+    // 3. pickupDate 포맷이 올바르지 않아 파싱에 실패하는 경우
+    @Test
+    void testRegisterCarShare_InvalidPickupDate() throws Exception {
+        CarShareRegiRequestDTO request = new CarShareRegiRequestDTO();
+        request.setPickupDate("invalid-date"); // ISO_LOCAL_DATE_TIME 포맷이 아님
+
+        when(authentication.getName()).thenReturn("1");
+        when(carRegistrationRepository.findCarIdByMemberId(1L)).thenReturn(100L);
+
+        // LocalDateTime.parse() 호출 시 DateTimeParseException 발생 예상
+        assertThrows(Exception.class, () -> controller.registerCarShare(request, authentication));
+    }
+
+    // 4. 정상 등록되는 경우
+    @Test
+    void testRegisterCarShare_Success() throws Exception {
+        CarShareRegiRequestDTO request = new CarShareRegiRequestDTO();
+        request.setPickupDate("2025-02-14T06:00");
+
+        when(authentication.getName()).thenReturn("1");
+        when(carRegistrationRepository.findCarIdByMemberId(1L)).thenReturn(100L);
+
+        // pickupDate 문자열을 파싱하여 기대하는 LocalDateTime 객체 생성
+        LocalDateTime expectedPickupDate = LocalDateTime.parse(request.getPickupDate(), DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+        // 등록 후 반환할 엔티티 생성 (ID 값 설정)
+        CarShareRegistration savedCarShare = new CarShareRegistration();
+        savedCarShare.setCarShareRegiId(200L);
+
+        when(carShareService.registerCarShare(request, 1L, 100L, expectedPickupDate))
+                .thenReturn(savedCarShare);
+
+        ResponseEntity<String> response = controller.registerCarShare(request, authentication);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("차량 공유 서비스 등록 성공 (ID: 200)", response.getBody());
+    }
+
+    // ──────────────── getMyCarShares ────────────────
+
+    // 5. 내 차량 공유 서비스 목록이 없을 경우 (empty list → 204 No Content)
+    @Test
+    void testGetMyCarShares_NoContent() {
+        when(authentication.getName()).thenReturn("1");
+        when(carShareService.getAllCarSharesByMemberId(1L)).thenReturn(new ArrayList<>());
+
+        ResponseEntity<List<CarShareRegistration>> response = controller.getMyCarShares(authentication);
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+
+    // 6. 내 차량 공유 서비스 목록이 있을 경우
+    @Test
+    void testGetMyCarShares_Success() {
+        when(authentication.getName()).thenReturn("1");
+        List<CarShareRegistration> list = new ArrayList<>();
+        CarShareRegistration reg = new CarShareRegistration();
+        reg.setCarShareRegiId(300L);
+        list.add(reg);
+
+        when(carShareService.getAllCarSharesByMemberId(1L)).thenReturn(list);
+
+        ResponseEntity<List<CarShareRegistration>> response = controller.getMyCarShares(authentication);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(list, response.getBody());
+    }
+}
+

--- a/bururung/src/test/java/com/hifive/bururung/domain/carshare/organizer/service/CarRegistrationServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/carshare/organizer/service/CarRegistrationServiceTest.java
@@ -1,0 +1,346 @@
+package com.hifive.bururung.domain.carshare.organizer.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.hifive.bururung.domain.carshare.organizer.entity.CarRegistration;
+import com.hifive.bururung.domain.carshare.organizer.repository.CarRegistrationRepository;
+import com.hifive.bururung.global.common.s3.S3Uploader;
+import com.hifive.bururung.global.common.s3.UploadFileDTO;
+import com.hifive.bururung.global.exception.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+public class CarRegistrationServiceTest {
+
+    @InjectMocks
+    private CarRegistrationService service;
+
+    @Mock
+    private CarRegistrationRepository carRegistrationRepository;
+
+    @Mock
+    private S3Uploader s3Uploader;
+
+    // ────────── isCarAlreadyRegistered ──────────
+
+    @Test
+    void testIsCarAlreadyRegistered_True() {
+        Long memberId = 1L;
+        when(carRegistrationRepository.existsByMember_MemberId(memberId)).thenReturn(true);
+        assertTrue(service.isCarAlreadyRegistered(memberId));
+        verify(carRegistrationRepository).existsByMember_MemberId(memberId);
+    }
+
+    @Test
+    void testIsCarAlreadyRegistered_False() {
+        Long memberId = 1L;
+        when(carRegistrationRepository.existsByMember_MemberId(memberId)).thenReturn(false);
+        assertFalse(service.isCarAlreadyRegistered(memberId));
+        verify(carRegistrationRepository).existsByMember_MemberId(memberId);
+    }
+
+    // ────────── isVerified ──────────
+
+    @Test
+    void testIsVerified_True() {
+        Long memberId = 1L;
+        when(carRegistrationRepository.findVerifiedByMemberId(memberId)).thenReturn("Y");
+        assertTrue(service.isVerified(memberId));
+        verify(carRegistrationRepository).findVerifiedByMemberId(memberId);
+    }
+
+    @Test
+    void testIsVerified_False() {
+        Long memberId = 1L;
+        when(carRegistrationRepository.findVerifiedByMemberId(memberId)).thenReturn("N");
+        assertFalse(service.isVerified(memberId));
+        verify(carRegistrationRepository).findVerifiedByMemberId(memberId);
+    }
+
+    @Test
+    void testIsVerified_Null() {
+        Long memberId = 1L;
+        when(carRegistrationRepository.findVerifiedByMemberId(memberId)).thenReturn(null);
+        assertFalse(service.isVerified(memberId));
+        verify(carRegistrationRepository).findVerifiedByMemberId(memberId);
+    }
+
+    // ────────── registerCar ──────────
+
+    @Test
+    void testRegisterCar() {
+        CarRegistration car = new CarRegistration();
+        when(carRegistrationRepository.save(car)).thenReturn(car);
+        CarRegistration result = service.registerCar(car);
+        assertSame(car, result);
+        verify(carRegistrationRepository).save(car);
+    }
+
+    // ────────── getAllCars ──────────
+
+    @Test
+    void testGetAllCars() {
+        List<CarRegistration> list = Arrays.asList(new CarRegistration(), new CarRegistration());
+        when(carRegistrationRepository.findAll()).thenReturn(list);
+        List<CarRegistration> result = service.getAllCars();
+        assertEquals(list, result);
+        verify(carRegistrationRepository).findAll();
+    }
+
+    // ────────── getCarByCarId ──────────
+
+    @Test
+    void testGetCarByCarId_Present() {
+        Long carId = 10L;
+        CarRegistration car = new CarRegistration();
+        when(carRegistrationRepository.findById(carId)).thenReturn(Optional.of(car));
+        Optional<CarRegistration> result = service.getCarByCarId(carId);
+        assertTrue(result.isPresent());
+        assertSame(car, result.get());
+        verify(carRegistrationRepository).findById(carId);
+    }
+
+    @Test
+    void testGetCarByCarId_Empty() {
+        Long carId = 10L;
+        when(carRegistrationRepository.findById(carId)).thenReturn(Optional.empty());
+        Optional<CarRegistration> result = service.getCarByCarId(carId);
+        assertFalse(result.isPresent());
+        verify(carRegistrationRepository).findById(carId);
+    }
+
+    // ────────── getCarByCarNumber ──────────
+
+    @Test
+    void testGetCarByCarNumber_Present() {
+        String carNumber = "ABC123";
+        CarRegistration car = new CarRegistration();
+        when(carRegistrationRepository.findByCarNumber(carNumber)).thenReturn(Optional.of(car));
+        Optional<CarRegistration> result = service.getCarByCarNumber(carNumber);
+        assertTrue(result.isPresent());
+        assertSame(car, result.get());
+        verify(carRegistrationRepository).findByCarNumber(carNumber);
+    }
+
+    @Test
+    void testGetCarByCarNumber_Empty() {
+        String carNumber = "ABC123";
+        when(carRegistrationRepository.findByCarNumber(carNumber)).thenReturn(Optional.empty());
+        Optional<CarRegistration> result = service.getCarByCarNumber(carNumber);
+        assertFalse(result.isPresent());
+        verify(carRegistrationRepository).findByCarNumber(carNumber);
+    }
+
+    // ────────── getCarByMemberId ──────────
+
+    @Test
+    void testGetCarByMemberId_Present() {
+        Long memberId = 1L;
+        CarRegistration car = new CarRegistration();
+        when(carRegistrationRepository.findByMember_MemberId(memberId)).thenReturn(Optional.of(car));
+        Optional<CarRegistration> result = service.getCarByMemberId(memberId);
+        assertTrue(result.isPresent());
+        assertSame(car, result.get());
+        verify(carRegistrationRepository).findByMember_MemberId(memberId);
+    }
+
+    @Test
+    void testGetCarByMemberId_Empty() {
+        Long memberId = 1L;
+        when(carRegistrationRepository.findByMember_MemberId(memberId)).thenReturn(Optional.empty());
+        Optional<CarRegistration> result = service.getCarByMemberId(memberId);
+        assertFalse(result.isPresent());
+        verify(carRegistrationRepository).findByMember_MemberId(memberId);
+    }
+
+    // ────────── updateCar ──────────
+
+    @Test
+    void testUpdateCar() {
+        CarRegistration car = new CarRegistration();
+        when(carRegistrationRepository.save(car)).thenReturn(car);
+        CarRegistration result = service.updateCar(car);
+        assertSame(car, result);
+        verify(carRegistrationRepository).save(car);
+    }
+
+    // ────────── deleteCar ──────────
+
+    @Test
+    void testDeleteCar_Success() {
+        Long carId = 5L;
+        when(carRegistrationRepository.existsById(carId)).thenReturn(true);
+        service.deleteCar(carId);
+        verify(carRegistrationRepository).existsById(carId);
+        verify(carRegistrationRepository).deleteById(carId);
+    }
+
+    @Test
+    void testDeleteCar_Failure() {
+        Long carId = 5L;
+        when(carRegistrationRepository.existsById(carId)).thenReturn(false);
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> service.deleteCar(carId));
+        assertEquals("해당 차량이 존재하지 않습니다.", exception.getMessage());
+        verify(carRegistrationRepository).existsById(carId);
+        verify(carRegistrationRepository, never()).deleteById(carId);
+    }
+
+    // ────────── isCarNumberExists ──────────
+
+    @Test
+    void testIsCarNumberExists_True() {
+        String carNumber = "ABC123";
+        when(carRegistrationRepository.countByCarNumber(carNumber)).thenReturn(2L);
+        assertTrue(service.isCarNumberExists(carNumber));
+        verify(carRegistrationRepository).countByCarNumber(carNumber);
+    }
+
+    @Test
+    void testIsCarNumberExists_False_Zero() {
+        String carNumber = "ABC123";
+        when(carRegistrationRepository.countByCarNumber(carNumber)).thenReturn(0L);
+        assertFalse(service.isCarNumberExists(carNumber));
+        verify(carRegistrationRepository).countByCarNumber(carNumber);
+    }
+
+    @Test
+    void testIsCarNumberExists_False_Null() {
+        String carNumber = "ABC123";
+        when(carRegistrationRepository.countByCarNumber(carNumber)).thenReturn(null);
+        assertFalse(service.isCarNumberExists(carNumber));
+        verify(carRegistrationRepository).countByCarNumber(carNumber);
+    }
+
+    // ────────── uploadCarImage ──────────
+
+    @Test
+    void testUploadCarImage_CarNotFound() {
+        Long memberId = 1L;
+        String subpath = "cars/";
+        MultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "dummy".getBytes());
+        when(carRegistrationRepository.findByMember_MemberId(memberId)).thenReturn(Optional.empty());
+
+        CustomException exception = assertThrows(CustomException.class, () ->
+            service.uploadCarImage(file, subpath, memberId)
+        );
+        // 추가 검증: 예외 코드 등 (필요시)
+        verify(carRegistrationRepository).findByMember_MemberId(memberId);
+        verifyNoInteractions(s3Uploader);
+    }
+
+    @Test
+    void testUploadCarImage_WithExistingImage() throws IOException {
+        Long memberId = 1L;
+        String subpath = "cars/";
+        MultipartFile file = new MockMultipartFile("file", "new.jpg", "image/jpeg", "new image".getBytes());
+
+        CarRegistration car = new CarRegistration();
+        car.setImageUrl("existingUrl");
+        car.setImageName("oldImage.jpg");
+
+        when(carRegistrationRepository.findByMember_MemberId(memberId)).thenReturn(Optional.of(car));
+
+        UploadFileDTO uploadResult = new UploadFileDTO();
+        uploadResult.setStoreFileName("newImage.jpg");
+        uploadResult.setStoreFullUrl("http://s3.example.com/newImage.jpg");
+
+        when(s3Uploader.uploadFile(file, subpath)).thenReturn(uploadResult);
+
+        String resultUrl = service.uploadCarImage(file, subpath, memberId);
+
+        // 기존 이미지가 존재하므로 삭제 호출
+        verify(s3Uploader).deleteFile(subpath + "oldImage.jpg");
+        verify(s3Uploader).uploadFile(file, subpath);
+        assertEquals("http://s3.example.com/newImage.jpg", resultUrl);
+        assertEquals("newImage.jpg", car.getImageName());
+        assertEquals("http://s3.example.com/newImage.jpg", car.getImageUrl());
+    }
+
+    @Test
+    void testUploadCarImage_NoExistingImage() throws IOException {
+        Long memberId = 1L;
+        String subpath = "cars/";
+        MultipartFile file = new MockMultipartFile("file", "new.jpg", "image/jpeg", "new image".getBytes());
+
+        CarRegistration car = new CarRegistration();
+        car.setImageUrl(""); // 빈 문자열로 기존 이미지 없음
+        car.setImageName(null);
+
+        when(carRegistrationRepository.findByMember_MemberId(memberId)).thenReturn(Optional.of(car));
+
+        UploadFileDTO uploadResult = new UploadFileDTO();
+        uploadResult.setStoreFileName("newImage.jpg");
+        uploadResult.setStoreFullUrl("http://s3.example.com/newImage.jpg");
+
+        when(s3Uploader.uploadFile(file, subpath)).thenReturn(uploadResult);
+
+        String resultUrl = service.uploadCarImage(file, subpath, memberId);
+
+        verify(s3Uploader, never()).deleteFile(anyString());
+        verify(s3Uploader).uploadFile(file, subpath);
+        assertEquals("http://s3.example.com/newImage.jpg", resultUrl);
+        assertEquals("newImage.jpg", car.getImageName());
+        assertEquals("http://s3.example.com/newImage.jpg", car.getImageUrl());
+    }
+
+    // ────────── uploadVerifiedFile ──────────
+
+    @Test
+    void testUploadVerifiedFile_CarNotFound() {
+        Long memberId = 1L;
+        String subpath = "verified/";
+        MultipartFile file = new MockMultipartFile("file", "verified.pdf", "application/pdf", "dummy".getBytes());
+        when(carRegistrationRepository.findByMember_MemberId(memberId)).thenReturn(Optional.empty());
+
+        CustomException exception = assertThrows(CustomException.class, () ->
+            service.uploadVerifiedFile(file, subpath, memberId)
+        );
+        verify(carRegistrationRepository).findByMember_MemberId(memberId);
+        verifyNoInteractions(s3Uploader);
+    }
+
+    @Test
+    void testUploadVerifiedFile_Success() throws IOException {
+        Long memberId = 1L;
+        String subpath = "verified/";
+        MultipartFile file = new MockMultipartFile("file", "verified.pdf", "application/pdf", "dummy".getBytes());
+
+        CarRegistration car = new CarRegistration();
+        when(carRegistrationRepository.findByMember_MemberId(memberId)).thenReturn(Optional.of(car));
+
+        UploadFileDTO uploadResult = new UploadFileDTO();
+        uploadResult.setStoreFileName("verifiedFile.pdf");
+        uploadResult.setStoreFullUrl("http://s3.example.com/verifiedFile.pdf");
+
+        when(s3Uploader.uploadFile(file, subpath)).thenReturn(uploadResult);
+
+        String resultUrl = service.uploadVerifiedFile(file, subpath, memberId);
+
+        verify(s3Uploader).uploadFile(file, subpath);
+        assertEquals("http://s3.example.com/verifiedFile.pdf", resultUrl);
+        // 최종적으로 verifiedFile에 저장된 값은 full URL
+        assertEquals("http://s3.example.com/verifiedFile.pdf", car.getVerifiedFile());
+    }
+}
+

--- a/bururung/src/test/java/com/hifive/bururung/domain/carshare/organizer/service/CarShareServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/carshare/organizer/service/CarShareServiceTest.java
@@ -1,0 +1,112 @@
+package com.hifive.bururung.domain.carshare.organizer.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.carshare.organizer.dto.CarShareRegiRequestDTO;
+import com.hifive.bururung.domain.carshare.organizer.entity.CarShareRegistration;
+import com.hifive.bururung.domain.carshare.organizer.repository.CarShareRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class CarShareServiceTest {
+
+    @InjectMocks
+    private CarShareService carShareService;
+
+    @Mock
+    private CarShareRepository carShareRepository;
+
+    // ────────────── registerCarShare ──────────────
+
+    @Test
+    void testRegisterCarShare_Success() {
+        // 준비: DTO 생성 및 필드 세팅
+        CarShareRegiRequestDTO request = new CarShareRegiRequestDTO();
+        request.setPickupLoc("Location A");
+        request.setLatitudePl(37.12345);
+        request.setLongitudePl(127.12345);
+        request.setSidoPl("Seoul");
+        request.setSigunguPl("Gangnam-gu");
+        request.setRoadnamePl("Gangnam-daero");
+        request.setDestination("Destination B");
+        request.setLatitudeDs(37.54321);
+        request.setLongitudeDs(127.54321);
+        request.setSidoDs("Busan");
+        request.setSigunguDs("Haeundae-gu");
+        request.setRoadnameDs("Haeundae-ro");
+        request.setPassengersNum(4);
+        request.setCategory("Standard");
+
+        Long memberId = 1L;
+        Long carId = 100L;
+        LocalDateTime pickupDateTime = LocalDateTime.of(2025, 2, 14, 6, 0);
+
+        // repository.save() 호출 시 인자로 전달된 엔티티를 그대로 반환하도록 설정
+        when(carShareRepository.save(any(CarShareRegistration.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // 메서드 호출
+        CarShareRegistration result = carShareService.registerCarShare(request, memberId, carId, pickupDateTime);
+
+        // 검증: 각 필드가 DTO와 입력값에 따라 올바르게 세팅되었는지 확인
+        assertNotNull(result);
+        assertEquals(memberId, result.getMemberId());
+        assertEquals(carId, result.getCarId());
+        assertEquals(request.getPickupLoc(), result.getPickupLoc());
+        assertEquals(request.getLatitudePl(), result.getLatitudePl());
+        assertEquals(request.getLongitudePl(), result.getLongitudePl());
+        assertEquals(request.getSidoPl(), result.getSidoPl());
+        assertEquals(request.getSigunguPl(), result.getSigunguPl());
+        // 빌더로 생성 시 roadname 필드 이름이 다를 수 있으므로 실제 getter 명칭에 맞게 수정 필요
+        assertEquals(request.getRoadnamePl(), result.getRoadNamePl());
+        assertEquals(request.getDestination(), result.getDestination());
+        assertEquals(request.getLatitudeDs(), result.getLatitudeDs());
+        assertEquals(request.getLongitudeDs(), result.getLongitudeDs());
+        assertEquals(request.getSidoDs(), result.getSidoDs());
+        assertEquals(request.getSigunguDs(), result.getSigunguDs());
+        // 빌더로 생성 시 roadname 필드 이름이 다를 수 있으므로 실제 getter 명칭에 맞게 수정 필요
+        assertEquals(request.getRoadnameDs(), result.getRoadNameDs());
+        assertEquals(request.getPassengersNum(), result.getPassengersNum());
+        assertEquals(pickupDateTime, result.getPickupDate());
+        assertEquals(request.getCategory(), result.getCategory());
+
+        // repository.save() 호출 여부 검증
+        verify(carShareRepository).save(any(CarShareRegistration.class));
+    }
+
+    // ────────────── getAllCarSharesByMemberId ──────────────
+
+    @Test
+    void testGetAllCarSharesByMemberId_Success() {
+        Long memberId = 1L;
+        List<CarShareRegistration> dummyList = new ArrayList<>();
+        CarShareRegistration reg1 = new CarShareRegistration();
+        reg1.setCarShareRegiId(10L);
+        dummyList.add(reg1);
+        CarShareRegistration reg2 = new CarShareRegistration();
+        reg2.setCarShareRegiId(20L);
+        dummyList.add(reg2);
+
+        when(carShareRepository.findByMemberId(memberId)).thenReturn(dummyList);
+
+        List<CarShareRegistration> result = carShareService.getAllCarSharesByMemberId(memberId);
+        assertNotNull(result);
+        assertEquals(dummyList.size(), result.size());
+        assertEquals(dummyList, result);
+
+        verify(carShareRepository).findByMemberId(memberId);
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/carshare/participant/controller/ServiceRegistrationControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/carshare/participant/controller/ServiceRegistrationControllerTest.java
@@ -1,0 +1,501 @@
+package com.hifive.bururung.domain.carshare.participant.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.hifive.bururung.domain.carshare.participant.dto.AllCarListResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.AvailableCarShareListResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.CarInformationResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.DriverInformationResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.DrivingInformationResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.PastParticipationListResponse;
+import com.hifive.bururung.domain.carshare.participant.service.IServiceRegistrationService;
+
+@ExtendWith(MockitoExtension.class)
+public class ServiceRegistrationControllerTest {
+
+    @InjectMocks
+    private ServiceRegistrationController controller;
+
+    @Mock
+    private IServiceRegistrationService registrationService;
+    
+    @Mock
+    private AvailableCarShareListResponse availableCarShareListResponse;
+    
+    @Mock
+    private DriverInformationResponse driverInformationResponse;
+    
+    @Mock
+    private CarInformationResponse carInformationResponse;
+    
+    @Mock
+    private DrivingInformationResponse drivingInformationResponse;
+    
+    @Mock
+    private AllCarListResponse allCarListResponse;
+    
+    @Mock
+    private PastParticipationListResponse pastParticipationListResponse;
+
+    // 1. GET /available-list
+    @Test
+    void testGetAvailableCarShareList_Empty() {
+        when(registrationService.getAvailableCarShareList()).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<AvailableCarShareListResponse>> response = controller.getAvailableCarShareList();
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(registrationService).getAvailableCarShareList();
+    }
+
+    @Test
+    void testGetAvailableCarShareList_Success() {
+        List<AvailableCarShareListResponse> list = new ArrayList<>();
+        list.add(availableCarShareListResponse);
+        when(registrationService.getAvailableCarShareList()).thenReturn(list);
+
+        ResponseEntity<List<AvailableCarShareListResponse>> response = controller.getAvailableCarShareList();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(list, response.getBody());
+        verify(registrationService).getAvailableCarShareList();
+    }
+
+    @Test
+    void testGetAvailableCarShareList_Exception() {
+        when(registrationService.getAvailableCarShareList()).thenThrow(new RuntimeException("error"));
+
+        ResponseEntity<List<AvailableCarShareListResponse>> response = controller.getAvailableCarShareList();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(registrationService).getAvailableCarShareList();
+    }
+
+    // 2. GET /driver-information/{memberId}
+    @Test
+    void testGetDriverInformation_Success() {
+        Long memberId = 1L;
+        DriverInformationResponse driverInfo = driverInformationResponse;
+        when(registrationService.getDriverInformation(memberId)).thenReturn(driverInfo);
+
+        ResponseEntity<Object> response = controller.getCarShareDetailInformation(memberId);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(driverInfo, response.getBody());
+        verify(registrationService).getDriverInformation(memberId);
+    }
+
+    @Test
+    void testGetDriverInformation_NullResponse() {
+        Long memberId = 1L;
+        when(registrationService.getDriverInformation(memberId)).thenReturn(null);
+
+        ResponseEntity<Object> response = controller.getCarShareDetailInformation(memberId);
+        String expectedMessage = "(정보) " + memberId + "번 사용자는 운전자로 등록되어 있지 않습니다.";
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).getDriverInformation(memberId);
+    }
+
+    @Test
+    void testGetDriverInformation_RuntimeException() {
+        Long memberId = 1L;
+        when(registrationService.getDriverInformation(memberId)).thenThrow(new RuntimeException("dummy"));
+
+        ResponseEntity<Object> response = controller.getCarShareDetailInformation(memberId);
+        String expectedMessage = "(정보) " + memberId + "번 사용자는 운전자로 등록되어 있지 않습니다.";
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).getDriverInformation(memberId);
+    }
+
+    @Test
+    void testGetDriverInformation_Exception() {
+        Long memberId = 1L;
+        when(registrationService.getDriverInformation(memberId)).thenThrow(new Exception("dummy"));
+
+        ResponseEntity<Object> response = controller.getCarShareDetailInformation(memberId);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(registrationService).getDriverInformation(memberId);
+    }
+
+    // 3. GET /car-information/{memberId}
+    @Test
+    void testGetCarInformation_Success() {
+        Long memberId = 1L;
+        CarInformationResponse carInfo = carInformationResponse;
+        when(registrationService.getCarInformation(memberId)).thenReturn(carInfo);
+
+        ResponseEntity<Object> response = controller.getCarInformation(memberId);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(carInfo, response.getBody());
+        verify(registrationService).getCarInformation(memberId);
+    }
+
+    @Test
+    void testGetCarInformation_NullResponse() {
+        Long memberId = 1L;
+        when(registrationService.getCarInformation(memberId)).thenReturn(null);
+
+        ResponseEntity<Object> response = controller.getCarInformation(memberId);
+        String expectedMessage = "(정보) " + memberId + "번 사용자의 차량은 등록되어 있지 않습니다.";
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).getCarInformation(memberId);
+    }
+
+    @Test
+    void testGetCarInformation_RuntimeException() {
+        Long memberId = 1L;
+        when(registrationService.getCarInformation(memberId)).thenThrow(new RuntimeException("dummy"));
+
+        ResponseEntity<Object> response = controller.getCarInformation(memberId);
+        String expectedMessage = "(정보) " + memberId + "번 사용자의 차량은 등록되어 있지 않습니다.";
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).getCarInformation(memberId);
+    }
+
+    @Test
+    void testGetCarInformation_Exception() {
+        Long memberId = 1L;
+        when(registrationService.getCarInformation(memberId)).thenThrow(new Exception("dummy"));
+
+        ResponseEntity<Object> response = controller.getCarInformation(memberId);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(registrationService).getCarInformation(memberId);
+    }
+
+    // 4. GET /driving-information?memberId=&carShareRegiId=
+    @Test
+    void testGetDrivingInformation_Success() {
+        Long memberId = 1L;
+        Long carShareRegiId = 10L;
+        DrivingInformationResponse drivingInfo = drivingInformationResponse;
+        when(registrationService.getDrivingInformation(memberId, carShareRegiId))
+            .thenReturn(drivingInfo);
+
+        ResponseEntity<Object> response = controller.getDrivingInformation(memberId, carShareRegiId);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(drivingInfo, response.getBody());
+        verify(registrationService).getDrivingInformation(memberId, carShareRegiId);
+    }
+
+    @Test
+    void testGetDrivingInformation_NullResponse() {
+        Long memberId = 1L;
+        Long carShareRegiId = 10L;
+        when(registrationService.getDrivingInformation(memberId, carShareRegiId))
+            .thenReturn(null);
+        String expectedMessage = "(정보) " + carShareRegiId + "번 차량 공유에 대한 운행 정보가 없습니다.";
+
+        ResponseEntity<Object> response = controller.getDrivingInformation(memberId, carShareRegiId);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).getDrivingInformation(memberId, carShareRegiId);
+    }
+
+    @Test
+    void testGetDrivingInformation_RuntimeException() {
+        Long memberId = 1L;
+        Long carShareRegiId = 10L;
+        when(registrationService.getDrivingInformation(memberId, carShareRegiId))
+            .thenThrow(new RuntimeException("dummy"));
+        String expectedMessage = "(정보) " + carShareRegiId + "번 차량 공유에 대한 운행 정보가 없습니다.";
+
+        ResponseEntity<Object> response = controller.getDrivingInformation(memberId, carShareRegiId);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).getDrivingInformation(memberId, carShareRegiId);
+    }
+
+    @Test
+    void testGetDrivingInformation_Exception() {
+        Long memberId = 1L;
+        Long carShareRegiId = 10L;
+        when(registrationService.getDrivingInformation(memberId, carShareRegiId))
+            .thenThrow(new Exception("dummy"));
+
+        ResponseEntity<Object> response = controller.getDrivingInformation(memberId, carShareRegiId);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(registrationService).getDrivingInformation(memberId, carShareRegiId);
+    }
+
+    // 5. POST /reservation
+    @Test
+    void testRegisterCarShare_InsufficientCredit() {
+        Long carShareRegiId = 10L;
+        Long userId = 1L;
+        // leftCredit < 7
+        when(registrationService.findLeftoverCredit(userId)).thenReturn(5);
+
+        String result = controller.registerCarShare(carShareRegiId, userId);
+        assertEquals("잔여 크레딧이 부족합니다.", result);
+
+        verify(registrationService).findLeftoverCredit(userId);
+        verify(registrationService, never()).insertRegistration(anyLong(), anyLong());
+    }
+
+    @Test
+    void testRegisterCarShare_SuccessReservation() {
+        Long carShareRegiId = 10L;
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenReturn(10);
+        when(registrationService.insertRegistration(carShareRegiId, userId)).thenReturn(true);
+
+        String result = controller.registerCarShare(carShareRegiId, userId);
+        assertEquals("차량 공유 예약에 성공했습니다.", result);
+
+        verify(registrationService).findLeftoverCredit(userId);
+        verify(registrationService).insertRegistration(carShareRegiId, userId);
+    }
+
+    @Test
+    void testRegisterCarShare_FailedReservation() {
+        Long carShareRegiId = 10L;
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenReturn(10);
+        when(registrationService.insertRegistration(carShareRegiId, userId)).thenReturn(false);
+
+        String result = controller.registerCarShare(carShareRegiId, userId);
+        assertEquals("차량 공유 예약에 실패했습니다.", result);
+
+        verify(registrationService).findLeftoverCredit(userId);
+        verify(registrationService).insertRegistration(carShareRegiId, userId);
+    }
+
+    @Test
+    void testRegisterCarShare_Exception() {
+        Long carShareRegiId = 10L;
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenThrow(new RuntimeException("error"));
+
+        String result = controller.registerCarShare(carShareRegiId, userId);
+        assertEquals("차량 공유 예약에 실패했습니다.", result);
+
+        verify(registrationService).findLeftoverCredit(userId);
+    }
+
+    // 6. GET /rating/{memberId}
+    @Test
+    void testFindRating() {
+        Long memberId = 1L;
+        Double rating = 4.5;
+        when(registrationService.findRating(memberId)).thenReturn(rating);
+
+        Double result = controller.findRating(memberId);
+        assertEquals(rating, result);
+        verify(registrationService).findRating(memberId);
+    }
+
+    // 7. GET /checked-credit
+    @Test
+    void testFindLeftoverCredit_Positive() {
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenReturn(10);
+
+        ResponseEntity<String> response = controller.findLeftoverCredit(userId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("잔여 크레딧은 10입니다.", response.getBody());
+        verify(registrationService).findLeftoverCredit(userId);
+    }
+
+    @Test
+    void testFindLeftoverCredit_Zero() {
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenReturn(0);
+
+        ResponseEntity<String> response = controller.findLeftoverCredit(userId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("잔여 크레딧은 0 입니다.", response.getBody());
+        verify(registrationService).findLeftoverCredit(userId);
+    }
+
+    @Test
+    void testFindLeftoverCredit_RuntimeException() {
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenThrow(new RuntimeException("error"));
+
+        ResponseEntity<String> response = controller.findLeftoverCredit(userId);
+        String expectedMessage = "(에러) " + userId + "번 회원의 크레딧 정보가 없습니다.";
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).findLeftoverCredit(userId);
+    }
+
+    @Test
+    void testFindLeftoverCredit_Exception() {
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenThrow(new Exception("error"));
+
+        ResponseEntity<String> response = controller.findLeftoverCredit(userId);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(registrationService).findLeftoverCredit(userId);
+    }
+
+    // 8. POST /deducted-credit
+    @Test
+    void testInsertCreditByCar_SufficientCredit() {
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenReturn(10);
+
+        ResponseEntity<String> response = controller.insertCreditByCar(userId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("7 크레딧이 차감되었습니다.", response.getBody());
+        verify(registrationService).findLeftoverCredit(userId);
+        verify(registrationService).insertCreditByCar(userId);
+    }
+
+    @Test
+    void testInsertCreditByCar_InsufficientCredit() {
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenReturn(5);
+
+        ResponseEntity<String> response = controller.insertCreditByCar(userId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("잔여 크레딧이 부족합니다.", response.getBody());
+        verify(registrationService).findLeftoverCredit(userId);
+        verify(registrationService, never()).insertCreditByCar(userId);
+    }
+
+    @Test
+    void testInsertCreditByCar_RuntimeException() {
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenThrow(new RuntimeException("error"));
+
+        ResponseEntity<String> response = controller.insertCreditByCar(userId);
+        String expectedMessage = "(에러) " + userId + "번 사용자에 대한 정보가 없습니다. error";
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).findLeftoverCredit(userId);
+    }
+
+    @Test
+    void testInsertCreditByCar_Exception() {
+        Long userId = 1L;
+        when(registrationService.findLeftoverCredit(userId)).thenThrow(new Exception("error"));
+
+        ResponseEntity<String> response = controller.insertCreditByCar(userId);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(registrationService).findLeftoverCredit(userId);
+    }
+
+    // 9. GET /all-list
+    @Test
+    void testFindAllShareCarList_Empty() {
+        when(registrationService.findAllShareCarList()).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<AllCarListResponse>> response = controller.findAllShareCarList();
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(registrationService).findAllShareCarList();
+    }
+
+    @Test
+    void testFindAllShareCarList_Success() {
+        List<AllCarListResponse> list = new ArrayList<>();
+        list.add(allCarListResponse);
+        when(registrationService.findAllShareCarList()).thenReturn(list);
+
+        ResponseEntity<List<AllCarListResponse>> response = controller.findAllShareCarList();
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(list, response.getBody());
+        verify(registrationService).findAllShareCarList();
+    }
+
+    @Test
+    void testFindAllShareCarList_Exception() {
+        when(registrationService.findAllShareCarList()).thenThrow(new RuntimeException("error"));
+
+        ResponseEntity<List<AllCarListResponse>> response = controller.findAllShareCarList();
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(registrationService).findAllShareCarList();
+    }
+
+    // 10. GET /past-list
+    @Test
+    void testFindPastParticipationList_NullResponse() {
+        Long userId = 1L;
+        when(registrationService.findPastParticipationList(userId)).thenReturn(null);
+        String expectedMessage = "(정보) " + userId + "번 사용자의 과거 탑승 내역이 없습니다.";
+
+        ResponseEntity<Object> response = controller.findPastParticipationList(userId);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).findPastParticipationList(userId);
+    }
+
+    @Test
+    void testFindPastParticipationList_Success() {
+        Long userId = 1L;
+        PastParticipationListResponse pastResponse = pastParticipationListResponse;
+        when(registrationService.findPastParticipationList(userId)).thenReturn(pastResponse);
+
+        ResponseEntity<Object> response = controller.findPastParticipationList(userId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(pastResponse, response.getBody());
+        verify(registrationService).findPastParticipationList(userId);
+    }
+
+    @Test
+    void testFindPastParticipationList_RuntimeException() {
+        Long userId = 1L;
+        when(registrationService.findPastParticipationList(userId)).thenThrow(new RuntimeException("error"));
+        String expectedMessage = "(정보) " + userId + "번 사용자의 과거 탑승 내역이 없습니다.";
+
+        ResponseEntity<Object> response = controller.findPastParticipationList(userId);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(expectedMessage, response.getBody());
+        verify(registrationService).findPastParticipationList(userId);
+    }
+
+    @Test
+    void testFindPastParticipationList_Exception() {
+        Long userId = 1L;
+        when(registrationService.findPastParticipationList(userId)).thenThrow(new Exception("error"));
+
+        ResponseEntity<Object> response = controller.findPastParticipationList(userId);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(registrationService).findPastParticipationList(userId);
+    }
+
+    // 11. GET /today-list
+    @Test
+    void testFindTodayParticipationList() {
+        Long userId = 1L;
+        List<PastParticipationListResponse> list = new ArrayList<>();
+        list.add(pastParticipationListResponse);
+        when(registrationService.findTodayParticipationList(userId)).thenReturn(list);
+
+        ResponseEntity<List<PastParticipationListResponse>> response = controller.findTodayParticipationList(userId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(list, response.getBody());
+        verify(registrationService).findTodayParticipationList(userId);
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/carshare/participant/service/ServiceRegistrationServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/carshare/participant/service/ServiceRegistrationServiceTest.java
@@ -1,0 +1,227 @@
+package com.hifive.bururung.domain.carshare.participant.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.carshare.participant.dto.AllCarListResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.AvailableCarShareListResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.CarInformationResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.DriverInformationResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.DrivingInformationResponse;
+import com.hifive.bururung.domain.carshare.participant.dto.PastParticipationListResponse;
+import com.hifive.bururung.domain.carshare.participant.repository.ServiceRegistrationRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class ServiceRegistrationServiceTest {
+
+    @InjectMocks
+    private ServiceRegistrationService service;
+
+    @Mock
+    private ServiceRegistrationRepository repository;
+    
+    @Mock
+    private AvailableCarShareListResponse availableCarShareListResponse;
+    
+    @Mock
+    private DriverInformationResponse driverInformationResponse;
+    
+    @Mock
+    private CarInformationResponse carInformationResponse;
+    
+    @Mock
+    private DrivingInformationResponse drivingInformationResponse;
+    
+    @Mock
+    private AllCarListResponse allCarListResponse;
+    
+    @Mock
+    private PastParticipationListResponse pastParticipationListResponse;
+
+    // 1. 현재 이용 가능한 공유 차량 목록
+    @Test
+    void testGetAvailableCarShareList() {
+        List<AvailableCarShareListResponse> list = new ArrayList<>();
+        list.add(availableCarShareListResponse);
+        when(repository.findAvailableCarShareList()).thenReturn(list);
+
+        List<AvailableCarShareListResponse> result = service.getAvailableCarShareList();
+        assertEquals(list, result);
+        verify(repository).findAvailableCarShareList();
+    }
+
+    // 2. 운전자 정보 조회
+    @Test
+    void testGetDriverInformation() {
+        Long memberId = 1L;
+        DriverInformationResponse driverInfo = driverInformationResponse;
+        when(repository.findDriverInformation(memberId)).thenReturn(driverInfo);
+
+        DriverInformationResponse result = service.getDriverInformation(memberId);
+        assertEquals(driverInfo, result);
+        verify(repository).findDriverInformation(memberId);
+    }
+
+    // 3. 차량 정보 조회
+    @Test
+    void testGetCarInformation() {
+        Long memberId = 1L;
+        CarInformationResponse carInfo = carInformationResponse;
+        when(repository.findCarInformation(memberId)).thenReturn(carInfo);
+
+        CarInformationResponse result = service.getCarInformation(memberId);
+        assertEquals(carInfo, result);
+        verify(repository).findCarInformation(memberId);
+    }
+
+    // 4. 차량 운행 정보 조회
+    @Test
+    void testGetDrivingInformation() {
+        Long memberId = 1L;
+        Long carShareRegiId = 10L;
+        DrivingInformationResponse drivingInfo = drivingInformationResponse;
+        // repository.findDrivingInformation()는 파라미터로 Map을 받음
+        when(repository.findDrivingInformation(any(Map.class))).thenReturn(drivingInfo);
+
+        DrivingInformationResponse result = service.getDrivingInformation(memberId, carShareRegiId);
+        assertEquals(drivingInfo, result);
+        // 전달된 Map이 올바른 값을 포함하는지 검증
+        verify(repository).findDrivingInformation(argThat(map ->
+            map instanceof HashMap &&
+            map.get("memberId").equals(memberId) &&
+            map.get("carShareRegiId").equals(carShareRegiId)
+        ));
+    }
+
+    // 5. 공유 차량 예약
+    // (1) 잔여 크레딧 부족: leftoverCredit < 7 → false 반환 및 insertRegistration 미호출
+    @Test
+    void testInsertRegistration_InsufficientCredit() {
+        Long carShareRegiId = 10L;
+        Long userId = 1L;
+        when(repository.findLeftoverCredit(userId)).thenReturn((int) 5L);  // 5 < 7
+
+        boolean result = service.insertRegistration(carShareRegiId, userId);
+        assertFalse(result);
+        verify(repository).findLeftoverCredit(userId);
+        verify(repository, never()).insertRegistration(any(Map.class));
+    }
+
+    // (2) 잔여 크레딧 충분: leftoverCredit >= 7 → true 반환 및 insertRegistration 호출
+    @Test
+    void testInsertRegistration_SufficientCredit() {
+        Long carShareRegiId = 10L;
+        Long userId = 1L;
+        when(repository.findLeftoverCredit(userId)).thenReturn((int) 7L); // 7 >= 7
+
+        boolean result = service.insertRegistration(carShareRegiId, userId);
+        assertTrue(result);
+        verify(repository).findLeftoverCredit(userId);
+        verify(repository).insertRegistration(argThat(map -> 
+            map instanceof HashMap &&
+            map.get("carShareRegiId").equals(carShareRegiId) &&
+            map.get("userId").equals(userId)
+        ));
+    }
+
+    // 6. 리뷰 평점 조회
+    @Test
+    void testFindRating() {
+        Long memberId = 1L;
+        Double rating = 4.5;
+        when(repository.findRating(memberId)).thenReturn(rating);
+
+        Double result = service.findRating(memberId);
+        assertEquals(rating, result);
+        verify(repository).findRating(memberId);
+    }
+
+    // 7. 잔여 크레딧 조회
+    @Test
+    void testFindLeftoverCredit() {
+        Long userId = 1L;
+        int leftover = 10;
+        when(repository.findLeftoverCredit(userId)).thenReturn(leftover);
+
+        int result = service.findLeftoverCredit(userId);
+        assertEquals(leftover, result);
+        verify(repository).findLeftoverCredit(userId);
+    }
+
+    // 8. 크레딧 차감
+    @Test
+    void testInsertCreditByCar() {
+        Long userId = 1L;
+        // 단순히 repository.insertCreditByCar 호출 여부 검증
+        service.insertCreditByCar(userId);
+        verify(repository).insertCreditByCar(userId);
+    }
+
+    // 9. 전체 공유 차량 목록 조회
+    @Test
+    void testFindAllShareCarList() {
+        List<AllCarListResponse> list = new ArrayList<>();
+        list.add(allCarListResponse);
+        when(repository.findAllShareCarList()).thenReturn(list);
+
+        List<AllCarListResponse> result = service.findAllShareCarList();
+        assertEquals(list, result);
+        verify(repository).findAllShareCarList();
+    }
+
+    // 10. 과거 차량 탑승 내역 조회
+    @Test
+    void testFindPastParticipationList() {
+        Long userId = 1L;
+        PastParticipationListResponse pastResponse = pastParticipationListResponse;
+        when(repository.findPastParticipationList(userId)).thenReturn(pastResponse);
+
+        PastParticipationListResponse result = service.findPastParticipationList(userId);
+        assertEquals(pastResponse, result);
+        verify(repository).findPastParticipationList(userId);
+    }
+
+    // 11. 오늘 차량 탑승 내역 조회
+    // (1) repository가 null을 반환하면 빈 리스트 반환
+    @Test
+    void testFindTodayParticipationList_Null() {
+        Long userId = 1L;
+        when(repository.findTodayParticipationList(userId)).thenReturn(null);
+
+        List<PastParticipationListResponse> result = service.findTodayParticipationList(userId);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(repository).findTodayParticipationList(userId);
+    }
+
+    // (2) repository가 non-null 리스트 반환
+    @Test
+    void testFindTodayParticipationList_NonNull() {
+        Long userId = 1L;
+        List<PastParticipationListResponse> list = new ArrayList<>();
+        list.add(pastParticipationListResponse);
+        when(repository.findTodayParticipationList(userId)).thenReturn(list);
+
+        List<PastParticipationListResponse> result = service.findTodayParticipationList(userId);
+        assertEquals(list, result);
+        verify(repository).findTodayParticipationList(userId);
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/credit/service/MemberCreditServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/credit/service/MemberCreditServiceTest.java
@@ -1,0 +1,83 @@
+package com.hifive.bururung.domain.credit.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.credit.entity.MemberCredit;
+import com.hifive.bururung.domain.credit.entity.MemberCreditState;
+import com.hifive.bururung.domain.credit.repository.MemberCreditRepository;
+import com.hifive.bururung.domain.member.entity.Member;
+import com.hifive.bururung.domain.member.repository.MemberRepository;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.MemberErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberCreditServiceTest {
+
+    @InjectMocks
+    private MemberCreditService memberCreditService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberCreditRepository memberCreditRepository;
+    
+    @Mock
+    private Member member;
+
+    // 정상 분기: 회원이 존재할 때, credit 충전 후 MemberCredit이 저장되는지 검증
+    @Test
+    void testChargeCredit_Success() {
+        Long memberId = 1L;
+        int creditCount = 50;
+        // member의 초기 상태는 테스트 환경에 맞게 설정(예: credit 값)
+        
+        // memberRepository.findById()가 Optional.of(member)를 반환하도록 설정
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        
+        // 서비스 메서드 호출
+        memberCreditService.chargeCredit(memberId, creditCount);
+        
+        // memberCreditRepository.save()에 전달된 MemberCredit 객체를 캡처하여 검증
+        ArgumentCaptor<MemberCredit> captor = ArgumentCaptor.forClass(MemberCredit.class);
+        verify(memberCreditRepository).save(captor.capture());
+        MemberCredit savedMemberCredit = captor.getValue();
+        
+        assertNotNull(savedMemberCredit);
+        assertEquals(member, savedMemberCredit.getMember());
+        assertEquals(creditCount, savedMemberCredit.getCount());
+        assertEquals(MemberCreditState.CHARGE, savedMemberCredit.getState());
+    }
+    
+    // 예외 분기: 회원이 존재하지 않으면 CustomException(USER_NOT_FOUND)이 발생하는지 검증
+    @Test
+    void testChargeCredit_MemberNotFound() {
+        Long memberId = 1L;
+        int creditCount = 50;
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+        
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            memberCreditService.chargeCredit(memberId, creditCount);
+        });
+        assertEquals(MemberErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        
+        verify(memberRepository).findById(memberId);
+        verify(memberCreditRepository, never()).save(any(MemberCredit.class));
+    }
+}
+

--- a/bururung/src/test/java/com/hifive/bururung/domain/email/controller/EmailControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/email/controller/EmailControllerTest.java
@@ -1,0 +1,85 @@
+package com.hifive.bururung.domain.email.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.hifive.bururung.domain.email.dto.EmailCheckRequest;
+import com.hifive.bururung.domain.email.dto.EmailSendRequest;
+import com.hifive.bururung.domain.email.dto.EmailType;
+import com.hifive.bururung.domain.email.service.EmailService;
+
+import jakarta.servlet.http.HttpSession;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailControllerTest {
+
+    @InjectMocks
+    private EmailController emailController;
+    
+    @Mock
+    private EmailService emailService;
+    
+    @Mock
+    private EmailSendRequest emailSendRequest;
+    
+    @Mock
+    private EmailCheckRequest emailCheckRequest;
+    
+    @Mock
+    private HttpSession httpSession;
+    
+    @Test
+    void testSendSignupMail() {
+        String email = "test@example.com";
+        String code = "123456";
+        when(emailSendRequest.getEmail()).thenReturn(email);
+        when(emailService.createCode(email)).thenReturn(code);
+        
+        ResponseEntity<?> response = emailController.sendSignupMail(emailSendRequest);
+        
+        verify(emailService).createCode(email);
+        verify(emailService).sendAuthenticationMail(EmailType.SIGNUP, email, code);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+    
+    @Test
+    void testSendChangePasswordMail() {
+        String email = "test@example.com";
+        String code = "654321";
+        when(emailSendRequest.getEmail()).thenReturn(email);
+        when(emailService.createCode(email)).thenReturn(code);
+        
+        ResponseEntity<?> response = emailController.sendChangePasswordMail(httpSession, emailSendRequest);
+        
+        verify(emailService).createCode(email);
+        verify(emailService).sendAuthenticationMail(EmailType.CHANGE_PASSWORD, email, code);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+    
+    @Test
+    void testCheckSignupAuthentication() {
+        String email = "test@example.com";
+        String code = "abcdef";
+        when(emailCheckRequest.getEmail()).thenReturn(email);
+        when(emailCheckRequest.getCode()).thenReturn(code);
+        when(emailService.isAuthenticated(email, code)).thenReturn(true);
+        
+        ResponseEntity<Boolean> response = emailController.checkSignupAuthentication(httpSession, emailCheckRequest);
+        
+        verify(emailService).isAuthenticated(email, code);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody());
+    }
+}
+
+

--- a/bururung/src/test/java/com/hifive/bururung/domain/email/service/EmailServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/email/service/EmailServiceTest.java
@@ -1,0 +1,121 @@
+package com.hifive.bururung.domain.email.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import com.hifive.bururung.domain.email.dto.EmailType;
+import com.hifive.bururung.global.common.RedisUtil;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.MemberErrorCode;
+
+import jakarta.mail.internet.MimeMessage;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailServiceTest {
+
+    @InjectMocks
+    private EmailService emailService;
+    
+    @Mock
+    private JavaMailSender javaMailSender;
+    
+    @Mock
+    private RedisUtil redisUtil;
+    
+    @BeforeEach
+    void setUp() {
+        // "id"는 @Value("${spring.mail.username}")로 주입되므로, 테스트에서는 모의값 "test"로 설정합니다.
+        org.springframework.test.util.ReflectionTestUtils.setField(emailService, "id", "test");
+    }
+    
+    // createCode(String email) 테스트
+    @Test
+    void testCreateCode() {
+        String email = "test@example.com";
+        // 호출 시 랜덤 6자리 코드가 반환됨
+        String code = emailService.createCode(email);
+        assertNotNull(code);
+        assertEquals(6, code.length());
+        
+        // redisUtil.setData()가 호출되었는지 검증
+        String expectedKey = "EMAIL_AUTH:" + email;
+        ArgumentCaptor<Duration> durationCaptor = ArgumentCaptor.forClass(Duration.class);
+        verify(redisUtil).setData(eq(expectedKey), eq(code), durationCaptor.capture());
+        assertEquals(Duration.ofSeconds(300), durationCaptor.getValue());
+    }
+    
+    // sendAuthenticationMail() 테스트 - EmailType.SIGNUP
+    @Test
+    void testSendAuthenticationMail_Signup() throws Exception {
+        String email = "test@example.com";
+        String code = "ABCDEF";
+        
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        
+        // 호출
+        emailService.sendAuthenticationMail(EmailType.SIGNUP, email, code);
+        
+        // 메일 전송을 위해 javaMailSender.send()가 호출되었는지 검증
+        verify(javaMailSender).send(mimeMessage);
+    }
+    
+    // sendAuthenticationMail() 테스트 - EmailType.CHANGE_PASSWORD
+    @Test
+    void testSendAuthenticationMail_ChangePassword() throws Exception {
+        String email = "test@example.com";
+        String code = "XYZ123";
+        
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        
+        emailService.sendAuthenticationMail(EmailType.CHANGE_PASSWORD, email, code);
+        
+        verify(javaMailSender).send(mimeMessage);
+    }
+    
+    // isAuthenticated() 테스트 - 성공 케이스
+    @Test
+    void testIsAuthenticated_Success() {
+        String email = "test@example.com";
+        String code = "ABCDEF";
+        
+        when(redisUtil.getData("EMAIL_AUTH:" + email)).thenReturn(code);
+        
+        boolean result = emailService.isAuthenticated(email, code);
+        assertTrue(result);
+    }
+    
+    // isAuthenticated() 테스트 - 실패 케이스
+    @Test
+    void testIsAuthenticated_Failure() {
+        String email = "test@example.com";
+        String code = "ABCDEF";
+        
+        when(redisUtil.getData("EMAIL_AUTH:" + email)).thenReturn("WRONG");
+        
+        CustomException exception = assertThrows(CustomException.class, () ->
+            emailService.isAuthenticated(email, code)
+        );
+        assertEquals(MemberErrorCode.EMAIL_AUTH_FAIL, exception.getErrorCode());
+    }
+}
+
+

--- a/bururung/src/test/java/com/hifive/bururung/domain/member/controller/MemberControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,137 @@
+package com.hifive.bururung.domain.member.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.hifive.bururung.domain.member.dto.ChangePasswordRequest;
+import com.hifive.bururung.domain.member.dto.FindEmailRequest;
+import com.hifive.bururung.domain.member.dto.LoginRequest;
+import com.hifive.bururung.domain.member.dto.LoginResponse;
+import com.hifive.bururung.domain.member.dto.SignupRequest;
+import com.hifive.bururung.domain.member.dto.TokenDTO;
+import com.hifive.bururung.domain.member.service.IMemberService;
+import com.hifive.bururung.global.common.CookieUtil;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberControllerTest {
+
+    @InjectMocks
+    private MemberController memberController;
+
+    @Mock
+    private IMemberService memberService;
+    
+    @Mock
+    private CookieUtil cookieUtil;
+    
+    @Mock
+    private HttpServletResponse response;
+    
+    @BeforeEach
+    void setUp() {
+        // refreshTokenValidity는 주입되는 값이므로 테스트 환경에서 임의의 값(예: 3600초)으로 설정합니다.
+        ReflectionTestUtils.setField(memberController, "refreshTokenValidity", 3600L);
+    }
+    
+    // 1. POST /api/member/login
+    @Test
+    void testLogin_Success() {
+        // given
+        String email = "user@example.com";
+        String password = "password123";
+        
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail(email);
+        loginRequest.setPassword(password);
+        
+        TokenDTO tokenDTO = new TokenDTO();
+        tokenDTO.setAccessToken("access-token");
+        tokenDTO.setRefreshToken("refresh-token");
+        
+        LoginResponse loginResponse = new LoginResponse();
+        // 필요에 따라 loginResponse 필드값 설정
+        
+        when(memberService.login(email, password)).thenReturn(tokenDTO);
+        when(memberService.getLoginResponse(email)).thenReturn(loginResponse);
+        
+        // when
+        ResponseEntity<LoginResponse> responseEntity = memberController.login(response, loginRequest);
+        
+        // then
+        // setAccessToken() 내부: response.setHeader("accesstoken", accessToken) 호출 검증
+        verify(response).setHeader("accesstoken", "access-token");
+        // setRefreshToken() 내부: cookieUtil.addCookie(response, "refreshtoken", refreshToken, refreshTokenValidity) 호출 검증
+        verify(cookieUtil).addCookie(response, "refreshtoken", "refresh-token", 3600);
+        
+        assertEquals(200, responseEntity.getStatusCodeValue());
+        assertEquals(loginResponse, responseEntity.getBody());
+    }
+    
+    // 2. POST /api/member/signup
+    @Test
+    void testSignup_Success() {
+        // given
+        SignupRequest signupRequest = new SignupRequest();
+        // 필요한 필드 설정 (예: 이메일, 이름 등)
+        
+        Long memberId = 1L;
+        when(memberService.signup(signupRequest)).thenReturn(memberId);
+        
+        // when
+        ResponseEntity<Long> responseEntity = memberController.signup(signupRequest);
+        
+        // then
+        assertEquals(200, responseEntity.getStatusCodeValue());
+        assertEquals(memberId, responseEntity.getBody());
+    }
+    
+    // 3. POST /api/member/find-email
+    @Test
+    void testFindEmail_Success() {
+        // given
+        FindEmailRequest findEmailRequest = new FindEmailRequest();
+        findEmailRequest.setName("John Doe");
+        findEmailRequest.setPhone("01012345678");
+        
+        String foundEmail = "john.doe@example.com";
+        when(memberService.findEmail("John Doe", "01012345678")).thenReturn(foundEmail);
+        
+        // when
+        ResponseEntity<String> responseEntity = memberController.findId(findEmailRequest);
+        
+        // then
+        assertEquals(200, responseEntity.getStatusCodeValue());
+        assertEquals(foundEmail, responseEntity.getBody());
+    }
+    
+    // 4. POST /api/member/change-password
+    @Test
+    void testChangePassword_Success() {
+        // given
+        ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest();
+        changePasswordRequest.setEmail("user@example.com");
+        changePasswordRequest.setPassword("newPassword123");
+        
+        Long changedId = 1L;
+        when(memberService.changePassword("user@example.com", "newPassword123")).thenReturn(changedId);
+        
+        // when
+        ResponseEntity<Long> responseEntity = memberController.changePassword(changePasswordRequest);
+        
+        // then
+        assertEquals(200, responseEntity.getStatusCodeValue());
+        assertEquals(changedId, responseEntity.getBody());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/member/controller/MypageControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/member/controller/MypageControllerTest.java
@@ -1,0 +1,98 @@
+package com.hifive.bururung.domain.member.controller;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.userdetails.User;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.member.dto.CreditHistoryResponse;
+import com.hifive.bururung.domain.member.dto.MypageResponse;
+import com.hifive.bururung.domain.member.service.IMypageService;
+import com.hifive.bururung.global.common.s3.FileSubPath;
+
+@ExtendWith(MockitoExtension.class)
+public class MypageControllerTest {
+
+    @InjectMocks
+    private MypageController mypageController;
+    
+    @Mock
+    private IMypageService mypageService;
+    
+    // 1. POST /api/mypage/upload-profile
+    @Test
+    void testUploadProfile_Success() throws IOException {
+        // 사용자 아이디를 문자열로 "1"로 설정 (memberId=1L)
+        User user = new User("1", "password", List.of());
+        // MultipartFile 생성 (프로필 이미지)
+        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "test.jpg", "image/jpeg", "dummy content".getBytes(StandardCharsets.UTF_8));
+        
+        // Service에서 반환할 URL 설정
+        String expectedUrl = "http://s3.example.com/profile.jpg";
+        when(mypageService.uploadProfile(profileImage, FileSubPath.MEMBER.getPath(), 1L)).thenReturn(expectedUrl);
+        
+        // Controller 호출
+        ResponseEntity<String> response = mypageController.uploadProfile(user, profileImage);
+        
+        // 검증: HTTP 200 OK와 반환된 URL
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(expectedUrl, response.getBody());
+    }
+    
+    // 2. GET /api/mypage/credit-history?year=&month=
+    @Test
+    void testGetCreditHistory_Success() {
+        User user = new User("1", "password", List.of());
+        int year = 2025;
+        int month = 2;
+        
+        // Dummy CreditHistoryResponse 목록 생성
+        CreditHistoryResponse history1 = new CreditHistoryResponse();
+        CreditHistoryResponse history2 = new CreditHistoryResponse();
+        List<CreditHistoryResponse> expectedList = Arrays.asList(history1, history2);
+        
+        when(mypageService.getCreditHistory(1L, year, month)).thenReturn(expectedList);
+        
+        ResponseEntity<List<CreditHistoryResponse>> response = mypageController.getCreditHistory(user, year, month);
+        
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(expectedList, response.getBody());
+    }
+    
+    // 3. GET /api/mypage/credit/{memberId}
+    @Test
+    void testGetCreditBalance_Success() {
+        Long memberId = 1L;
+        int expectedBalance = 100;
+        when(mypageService.getCreditBalance(memberId)).thenReturn(expectedBalance);
+        
+        ResponseEntity<Integer> response = mypageController.getCreditBalance(memberId);
+        
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(expectedBalance, response.getBody());
+    }
+    
+    // 4. GET /api/mypage (마이페이지 조회)
+    @Test
+    void testGetMypage_Success() {
+        User user = new User("1", "password", List.of());
+        MypageResponse expectedResponse = new MypageResponse();
+        when(mypageService.getMypage(1L)).thenReturn(expectedResponse);
+        
+        ResponseEntity<MypageResponse> response = mypageController.getMypage(user);
+        
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(expectedResponse, response.getBody());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/member/service/MemberServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,307 @@
+package com.hifive.bururung.domain.member.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.hifive.bururung.domain.member.dto.LoginResponse;
+import com.hifive.bururung.domain.member.dto.SignupRequest;
+import com.hifive.bururung.domain.member.dto.TokenDTO;
+import com.hifive.bururung.domain.member.entity.Member;
+import com.hifive.bururung.domain.member.repository.MemberRepository;
+import com.hifive.bururung.global.common.RedisUtil;
+import com.hifive.bururung.global.common.TokenProvider;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.MemberErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+    
+    @InjectMocks
+    private MemberService memberService;
+    
+    @Mock
+    private MemberRepository memberRepository;
+    
+    @Mock
+    private TokenProvider tokenProvider;
+    
+    @Mock
+    private AuthenticationManagerBuilder authenticationManagerBuilder;
+    
+    @Mock
+    private RedisUtil redisUtil;
+    
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    
+    // refreshTokenValidity를 주입 (예: 3600초)
+    private final Long refreshTokenValidity = 3600L;
+    
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(memberService, "refreshTokenValidity", refreshTokenValidity);
+    }
+    
+    // -------------------------------------
+    // 1. login()
+    // -------------------------------------
+    @Test
+    void testLogin_Success() {
+        String email = "user@example.com";
+        String password = "password";
+        
+        // @Mock으로 생성된 Authentication 객체
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn(email);
+        
+        // AuthenticationManager도 @Mock으로 생성
+        AuthenticationManager authManager = mock(AuthenticationManager.class);
+        when(authManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+            .thenReturn(authentication);
+        when(authenticationManagerBuilder.getObject()).thenReturn(authManager);
+        
+        // Stub TokenProvider
+        String accessToken = "access-token";
+        String refreshToken = "refresh-token";
+        when(tokenProvider.createAccessToken(authentication)).thenReturn(accessToken);
+        when(tokenProvider.createRefreshToken(authentication)).thenReturn(refreshToken);
+        
+        // Call login
+        TokenDTO tokenDTO = memberService.login(email, password);
+        
+        // Verify redisUtil.setData() 호출
+        String expectedKey = "REFRESH_TOKEN:" + email;
+        ArgumentCaptor<Duration> durationCaptor = ArgumentCaptor.forClass(Duration.class);
+        verify(redisUtil).setData(eq(expectedKey), eq(refreshToken), durationCaptor.capture());
+        assertEquals(Duration.ofSeconds(refreshTokenValidity), durationCaptor.getValue());
+        
+        // Verify TokenDTO 내용
+        assertNotNull(tokenDTO);
+        assertEquals(accessToken, tokenDTO.getAccessToken());
+        assertEquals(refreshToken, tokenDTO.getRefreshToken());
+    }
+    
+    // -------------------------------------
+    // 2. signup()
+    // -------------------------------------
+    @Test
+    void testSignup_Success() {
+        // SignupRequest를 @Mock으로 생성하고 stubbing
+        SignupRequest signupRequest = mock(SignupRequest.class);
+        when(signupRequest.getBirth()).thenReturn("2000-01-01");
+        when(signupRequest.getEmail()).thenReturn("newuser@example.com");
+        when(signupRequest.getGender()).thenReturn('M');
+        when(signupRequest.getName()).thenReturn("New User");
+        when(signupRequest.getPassword()).thenReturn("plainPassword");
+        when(signupRequest.getPhone()).thenReturn("01012345678");
+        when(signupRequest.getNickname()).thenReturn("newbie");
+        
+        // Simulate password encoding
+        String encodedPassword = "encodedPassword";
+        when(passwordEncoder.encode("plainPassword")).thenReturn(encodedPassword);
+        
+        // memberRepository.save()가 호출되었을 때, 스파이 객체(Member)를 반환하도록 구성
+        // Member는 도메인 객체이므로 @Spy로 생성 (new 키워드 없이 Mockito.spy() 사용)
+        Member memberSpy = spy(Member.class);
+        doReturn(1L).when(memberSpy).getMemberId();
+        // save() 메서드는 인자로 받은 객체를 그대로 반환하도록 stubbing
+        when(memberRepository.save(any(Member.class))).thenReturn(memberSpy);
+        
+        Long memberId = memberService.signup(signupRequest);
+        assertEquals(1L, memberId);
+        
+        // 캡처해서 전달된 Member 객체의 stubbing된 getter값 확인
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+        Member capturedMember = memberCaptor.getValue();
+        // stubbing된 값는 SignupRequest의 getter 결과로 예상됨
+        assertEquals("2000-01-01", capturedMember.getBirth());
+        assertEquals("newuser@example.com", capturedMember.getEmail());
+        assertEquals("M", capturedMember.getGender());
+        assertEquals("New User", capturedMember.getName());
+        assertEquals("ROLE_USER", capturedMember.getRoleName());
+        assertEquals(encodedPassword, capturedMember.getPassword());
+        assertEquals("01012345678", capturedMember.getPhone());
+        assertEquals("newbie", capturedMember.getNickname());
+    }
+    
+    // -------------------------------------
+    // 3. findEmail()
+    // -------------------------------------
+    @Test
+    void testFindEmail_Success() {
+        String name = "User";
+        String phone = "01012345678";
+        String foundEmail = "user@example.com";
+        
+        when(memberRepository.findEmailByNameAndPhone(name, phone)).thenReturn(Optional.of(foundEmail));
+        
+        String result = memberService.findEmail(name, phone);
+        assertEquals(foundEmail, result);
+    }
+    
+    @Test
+    void testFindEmail_NotFound() {
+        String name = "User";
+        String phone = "01012345678";
+        
+        when(memberRepository.findEmailByNameAndPhone(name, phone)).thenReturn(Optional.empty());
+        
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            memberService.findEmail(name, phone);
+        });
+        assertEquals(MemberErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+    
+    // -------------------------------------
+    // 4. checkMemberExists()
+    // -------------------------------------
+    @Test
+    void testCheckMemberExists_True() {
+        Long memberId = 1L;
+        when(memberRepository.existsById(memberId)).thenReturn(true);
+        
+        assertTrue(memberService.checkMemberExists(memberId));
+    }
+    
+    @Test
+    void testCheckMemberExists_False() {
+        Long memberId = 1L;
+        when(memberRepository.existsById(memberId)).thenReturn(false);
+        
+        assertFalse(memberService.checkMemberExists(memberId));
+    }
+    
+    // -------------------------------------
+    // 5. findByMemberId()
+    // -------------------------------------
+    @Test
+    void testFindByMemberId_Success() {
+        Long memberId = 1L;
+        // Member 객체는 @Spy로 생성 (new 키워드 없이 Mockito.spy() 사용)
+        Member memberSpy = spy(Member.class);
+        doReturn(memberId).when(memberSpy).getMemberId();
+        
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberSpy));
+        
+        Member result = memberService.findByMemberId(memberId);
+        assertEquals(memberSpy, result);
+    }
+    
+    @Test
+    void testFindByMemberId_NotFound() {
+        Long memberId = 1L;
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+        
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            memberService.findByMemberId(memberId);
+        });
+        assertEquals(MemberErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+    
+    // -------------------------------------
+    // 6. changePassword()
+    // -------------------------------------
+    @Test
+    void testChangePassword_Success() {
+        String email = "user@example.com";
+        String newPassword = "newPassword";
+        String encodedPassword = "encodedNewPassword";
+        
+        // Member 객체를 @Spy로 생성
+        Member memberSpy = spy(Member.class);
+        doReturn(1L).when(memberSpy).getMemberId();
+        // 초기 비밀번호는 "oldPassword" (stubbing)
+        doReturn("oldPassword").when(memberSpy).getPassword();
+        
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(memberSpy));
+        when(passwordEncoder.encode(newPassword)).thenReturn(encodedPassword);
+        
+        // 만약 changePassword() 메서드가 실제로 멤버의 상태를 변경한다면,
+        // 스파이 객체에서 해당 메서드를 호출하도록 하고, 그 후 getPassword()를 stubbing 변경
+        doAnswer(invocation -> {
+            String pwd = invocation.getArgument(0);
+            // stubbing: getPassword() returns encodedPassword
+            doReturn(encodedPassword).when(memberSpy).getPassword();
+            return null;
+        }).when(memberSpy).changePassword(anyString());
+        
+        Long resultMemberId = memberService.changePassword(email, newPassword);
+        assertEquals(1L, resultMemberId);
+        // verify that the member's password was updated to encodedPassword via stubbing
+        assertEquals(encodedPassword, memberSpy.getPassword());
+    }
+    
+    @Test
+    void testChangePassword_NotFound() {
+        String email = "nonexistent@example.com";
+        String newPassword = "newPassword";
+        
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
+        
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            memberService.changePassword(email, newPassword);
+        });
+        assertEquals(MemberErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+    
+    // -------------------------------------
+    // 7. getLoginResponse()
+    // -------------------------------------
+    @Test
+    void testGetLoginResponse_Success() {
+        String email = "user@example.com";
+        // Member 객체를 @Spy로 생성
+        Member memberSpy = spy(Member.class);
+        doReturn(1L).when(memberSpy).getMemberId();
+        doReturn("nickname").when(memberSpy).getNickname();
+        doReturn("ROLE_USER").when(memberSpy).getRoleName();
+        
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(memberSpy));
+        
+        LoginResponse response = memberService.getLoginResponse(email);
+        assertEquals(1L, response.getMemberId());
+        assertEquals("nickname", response.getNickname());
+        assertEquals("ROLE_USER", response.getRole());
+    }
+    
+    @Test
+    void testGetLoginResponse_NotFound() {
+        String email = "nonexistent@example.com";
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
+        
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            memberService.getLoginResponse(email);
+        });
+        assertEquals(MemberErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/member/service/MypageServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/member/service/MypageServiceTest.java
@@ -1,0 +1,152 @@
+package com.hifive.bururung.domain.member.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.hifive.bururung.domain.member.dto.CreditHistoryDTO;
+import com.hifive.bururung.domain.member.dto.CreditHistoryResponse;
+import com.hifive.bururung.domain.member.entity.Member;
+import com.hifive.bururung.domain.member.repository.MemberRepository;
+import com.hifive.bururung.domain.member.repository.MypageMapper;
+import com.hifive.bururung.global.common.s3.S3Uploader;
+import com.hifive.bururung.global.common.s3.UploadFileDTO;
+
+@ExtendWith(MockitoExtension.class)
+public class MypageServiceTest {
+
+    @InjectMocks
+    private MypageService mypageService;
+    
+    @Mock
+    private S3Uploader s3Uploader;
+    
+    @Mock
+    private MemberRepository memberRepository;
+    
+    @Mock
+    private MypageMapper mypageMapper;
+    
+    @Mock
+    private MultipartFile multipartFile;
+    
+    // 도메인 객체는 new 키워드 대신 @Spy를 사용하여 생성 (CALLS_REAL_METHODS로 실제 메서드 호출)
+    @Spy
+    private Member memberSpy = mock(Member.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    
+    @BeforeEach
+    void setUp() {
+        // 별도의 설정이 필요하면 여기에 작성 (현재는 특별한 설정 없음)
+    }
+    
+    // 1. uploadProfile: 기존 이미지가 있을 경우 (삭제 호출 확인)
+    @Test
+    void testUploadProfile_WithExistingImage() throws IOException {
+        Long memberId = 1L;
+        String subpath = "member/";
+        
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberSpy));
+        // 기존 이미지가 있음: non-empty 값 반환
+        when(memberSpy.getImageUrl()).thenReturn("existingUrl");
+        when(memberSpy.getImageName()).thenReturn("oldImage.jpg");
+        
+        // UploadFileDTO를 목으로 생성 (도메인 객체 대신 mock 사용)
+        UploadFileDTO uploadFileDTO = mock(UploadFileDTO.class);
+        when(uploadFileDTO.getStoreFileName()).thenReturn("newImage.jpg");
+        when(uploadFileDTO.getStoreFullUrl()).thenReturn("http://s3.example.com/newImage.jpg");
+        
+        when(s3Uploader.uploadFile(multipartFile, subpath)).thenReturn(uploadFileDTO);
+        
+        String resultUrl = mypageService.uploadProfile(multipartFile, subpath, memberId);
+        
+        // 기존 이미지가 있으므로 삭제가 호출되어야 함.
+        verify(s3Uploader).deleteFile(subpath + "oldImage.jpg");
+        verify(s3Uploader).uploadFile(multipartFile, subpath);
+        verify(memberSpy).changeProfile("newImage.jpg", "http://s3.example.com/newImage.jpg");
+        assertEquals("http://s3.example.com/newImage.jpg", resultUrl);
+    }
+    
+    // 2. uploadProfile: 기존 이미지가 없을 경우 (삭제 미호출)
+    @Test
+    void testUploadProfile_NoExistingImage() throws IOException {
+        Long memberId = 1L;
+        String subpath = "member/";
+        
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberSpy));
+        // 기존 이미지가 없으므로 빈 문자열 반환
+        when(memberSpy.getImageUrl()).thenReturn("");
+        
+        UploadFileDTO uploadFileDTO = mock(UploadFileDTO.class);
+        when(uploadFileDTO.getStoreFileName()).thenReturn("newImage.jpg");
+        when(uploadFileDTO.getStoreFullUrl()).thenReturn("http://s3.example.com/newImage.jpg");
+        
+        when(s3Uploader.uploadFile(multipartFile, subpath)).thenReturn(uploadFileDTO);
+        
+        String resultUrl = mypageService.uploadProfile(multipartFile, subpath, memberId);
+        
+        // 삭제 호출 없이 업로드 및 프로필 변경이 이루어져야 함.
+        verify(s3Uploader, never()).deleteFile(anyString());
+        verify(s3Uploader).uploadFile(multipartFile, subpath);
+        verify(memberSpy).changeProfile("newImage.jpg", "http://s3.example.com/newImage.jpg");
+        assertEquals("http://s3.example.com/newImage.jpg", resultUrl);
+    }
+    
+    // 3. getCreditHistory
+    @Test
+    void testGetCreditHistory() {
+        Long memberId = 1L;
+        int year = 2025;
+        int month = 2;
+        
+        // CreditHistoryDTO 대신 Object를 목으로 사용 (타입 정보가 없으므로)
+        CreditHistoryDTO creditHistoryDTO = mock(CreditHistoryDTO.class);
+        when(mypageMapper.getCreditHistoryByDate(memberId, year, month))
+            .thenReturn(Collections.singletonList(creditHistoryDTO));
+        
+        List<CreditHistoryResponse> responses = mypageService.getCreditHistory(memberId, year, month);
+        // 서비스 내부에서 new CreditHistoryResponse(dto) 호출 – 리스트 크기만 검증
+        assertEquals(1, responses.size());
+    }
+    
+    // 4. getCreditBalance
+    @Test
+    void testGetCreditBalance_Success() {
+        Long memberId = 1L;
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberSpy));
+        when(memberSpy.getCreditCount()).thenReturn(100);
+        
+        Integer balance = mypageService.getCreditBalance(memberId);
+        assertEquals(100, balance);
+    }
+    
+    // 5. getMypage
+    @Test
+    void testGetMypage_Success() {
+        Long memberId = 1L;
+        // MypageResponse 도메인 객체를 목으로 생성
+        com.hifive.bururung.domain.member.dto.MypageResponse mypageResponse = mock(com.hifive.bururung.domain.member.dto.MypageResponse.class);
+        when(mypageMapper.getMypage(memberId)).thenReturn(mypageResponse);
+        
+        com.hifive.bururung.domain.member.dto.MypageResponse response = mypageService.getMypage(memberId);
+        assertEquals(mypageResponse, response);
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/member/service/UserDetailsServiceImplTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/member/service/UserDetailsServiceImplTest.java
@@ -1,0 +1,80 @@
+package com.hifive.bururung.domain.member.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.hifive.bururung.domain.member.entity.Member;
+import com.hifive.bururung.domain.member.repository.MemberRepository;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.MemberErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+public class UserDetailsServiceImplTest {
+
+    @InjectMocks
+    private UserDetailsServiceImpl userDetailsServiceImpl;
+    
+    @Mock
+    private MemberRepository memberRepository;
+    
+    // Member 도메인 객체는 new 키워드 대신 @Spy로 생성
+    @Spy
+    private Member memberSpy = mock(Member.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    
+    @BeforeEach
+    void setUp() {
+        // 필요한 스터빙은 각 테스트에서 진행합니다.
+    }
+    
+    @Test
+    void testLoadUserByUsername_Success() {
+        String email = "user@example.com";
+        // stubbing: Member 객체의 getter 결과 설정
+        when(memberSpy.getMemberId()).thenReturn(1L);
+        when(memberSpy.getPassword()).thenReturn("encodedPassword");
+        when(memberSpy.getRoleName()).thenReturn("ROLE_USER");
+        
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(memberSpy));
+        
+        UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(email);
+        
+        // UserDetails의 username는 memberId의 문자열 값 ("1")
+        assertEquals("1", userDetails.getUsername());
+        assertEquals("encodedPassword", userDetails.getPassword());
+        
+        // 권한 목록 검증
+        Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+        assertNotNull(authorities);
+        assertTrue(authorities.stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_USER")));
+    }
+    
+    @Test
+    void testLoadUserByUsername_NotFound() {
+        String email = "nonexistent@example.com";
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
+        
+        CustomException exception = assertThrows(CustomException.class, () -> 
+            userDetailsServiceImpl.loadUserByUsername(email)
+        );
+        assertEquals(MemberErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/notification/controller/NotificationControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,220 @@
+package com.hifive.bururung.domain.notification.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.hifive.bururung.domain.notification.dto.NotificationDTO;
+import com.hifive.bururung.domain.notification.dto.NotificationListResponse;
+import com.hifive.bururung.domain.notification.entity.Notification;
+import com.hifive.bururung.domain.notification.service.INotificationService;
+import com.hifive.bururung.global.util.SecurityUtil;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationControllerTest {
+
+    @InjectMocks
+    private NotificationController notificationController;
+    
+    @Mock
+    private INotificationService notificationService;
+    
+    // 1. GET /api/notifications
+    @Test
+    void testGetNotifications() {
+        List<Notification> notifications = mock(List.class);
+        when(notificationService.getNotifications()).thenReturn(notifications);
+        
+        List<Notification> result = notificationController.getNotifications();
+        assertEquals(notifications, result);
+    }
+    
+    // 2. GET /api/notifications/read - 성공 케이스
+    @Test
+    void testGetReadNotifications_Success() {
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            Long memberId = 1L;
+            securityUtilMock.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+            
+            List<NotificationDTO> readList = mock(List.class);
+            when(notificationService.getReadNotifications(memberId)).thenReturn(readList);
+            
+            ResponseEntity<NotificationListResponse<List<NotificationDTO>>> response =
+                notificationController.getReadNotifications();
+            
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertEquals(readList, response.getBody().getData());
+            assertNull(response.getBody().getMessage());
+        }
+    }
+    
+    // 3. GET /api/notifications/read - 실패(Unauthorized)
+    @Test
+    void testGetReadNotifications_Unauthorized() {
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            String errorMsg = "Session expired";
+            securityUtilMock.when(SecurityUtil::getCurrentMemberId)
+                             .thenThrow(new IllegalArgumentException(errorMsg));
+            
+            ResponseEntity<NotificationListResponse<List<NotificationDTO>>> response =
+                notificationController.getReadNotifications();
+            
+            assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+            assertNull(response.getBody().getData());
+            assertEquals(errorMsg, response.getBody().getMessage());
+        }
+    }
+    
+    // 4. GET /api/notifications/unread - 성공 케이스
+    @Test
+    void testGetUnreadNotifications_Success() {
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            Long memberId = 2L;
+            securityUtilMock.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+            
+            List<NotificationDTO> unreadList = mock(List.class);
+            when(notificationService.getUnreadNotifications(memberId)).thenReturn(unreadList);
+            
+            ResponseEntity<NotificationListResponse<List<NotificationDTO>>> response =
+                notificationController.getUnreadNotifications();
+            
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertEquals(unreadList, response.getBody().getData());
+            assertNull(response.getBody().getMessage());
+        }
+    }
+    
+    // 5. GET /api/notifications/unread - 실패 (Unauthorized)
+    @Test
+    void testGetUnreadNotifications_Unauthorized() {
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            String errorMsg = "Invalid session";
+            securityUtilMock.when(SecurityUtil::getCurrentMemberId)
+                             .thenThrow(new IllegalStateException(errorMsg));
+            
+            ResponseEntity<NotificationListResponse<List<NotificationDTO>>> response =
+                notificationController.getUnreadNotifications();
+            
+            assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+            assertNull(response.getBody().getData());
+            assertEquals(errorMsg, response.getBody().getMessage());
+        }
+    }
+    
+    // 6. GET /api/notifications/bysender - 성공 케이스
+    @Test
+    void testGetNotificationBySenderId_Success() {
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            Long memberId = 3L;
+            securityUtilMock.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+            
+            List<NotificationDTO> senderList = mock(List.class);
+            when(notificationService.getNotificationsBySenderId(memberId)).thenReturn(senderList);
+            
+            ResponseEntity<NotificationListResponse<List<NotificationDTO>>> response =
+                notificationController.getNotificationBySenderId();
+            
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertEquals(senderList, response.getBody().getData());
+            assertNull(response.getBody().getMessage());
+        }
+    }
+    
+    // 7. GET /api/notifications/bysender - 실패 (Unauthorized)
+    @Test
+    void testGetNotificationBySenderId_Unauthorized() {
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            String errorMsg = "No session";
+            securityUtilMock.when(SecurityUtil::getCurrentMemberId)
+                             .thenThrow(new IllegalArgumentException(errorMsg));
+            
+            ResponseEntity<NotificationListResponse<List<NotificationDTO>>> response =
+                notificationController.getNotificationBySenderId();
+            
+            assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+            assertNull(response.getBody().getData());
+            assertEquals(errorMsg, response.getBody().getMessage());
+        }
+    }
+    
+    // 8. PUT /api/notifications/{notificationId} - readNotification 성공
+    @Test
+    void testReadNotification_Success() {
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            Long memberId = 4L;
+            Long notificationId = 10L;
+            securityUtilMock.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+            
+            List<NotificationDTO> readList = mock(List.class);
+            // Simulate that after marking as read, service returns updated read notifications.
+            when(notificationService.getReadNotifications(memberId)).thenReturn(readList);
+            
+            ResponseEntity<NotificationListResponse<List<NotificationDTO>>> response =
+                notificationController.readNotification(notificationId);
+            
+            // Verify that readNotification() on service was called with the correct parameters
+            verify(notificationService).readNotification(notificationId, memberId);
+            
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertEquals(readList, response.getBody().getData());
+            assertNull(response.getBody().getMessage());
+        }
+    }
+    
+    // 9. PUT /api/notifications/{notificationId} - readNotification 실패 (Unauthorized)
+    @Test
+    void testReadNotification_Unauthorized() {
+        Long notificationId = 10L;
+        String errorMsg = "Session error";
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentMemberId)
+                             .thenThrow(new IllegalArgumentException(errorMsg));
+            
+            ResponseEntity<NotificationListResponse<List<NotificationDTO>>> response =
+                notificationController.readNotification(notificationId);
+            
+            assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+            assertNull(response.getBody().getData());
+            assertEquals(errorMsg, response.getBody().getMessage());
+        }
+    }
+    
+    // 10. DELETE /api/notifications/{notificationId} - 성공
+    @Test
+    void testDeleteNotification_Success() {
+        Long notificationId = 20L;
+        doNothing().when(notificationService).deleteNotification(notificationId);
+        
+        ResponseEntity<String> response = notificationController.deleteNotification(notificationId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("ok", response.getBody());
+    }
+    
+    // 11. DELETE /api/notifications/{notificationId} - 실패
+    @Test
+    void testDeleteNotification_Failure() {
+        Long notificationId = 20L;
+        String exceptionMsg = "Delete error";
+        doThrow(new RuntimeException(exceptionMsg)).when(notificationService).deleteNotification(notificationId);
+        
+        ResponseEntity<String> response = notificationController.deleteNotification(notificationId);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(exceptionMsg, response.getBody());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/notification/service/NotificationServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,147 @@
+package com.hifive.bururung.domain.notification.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.hifive.bururung.domain.notification.dto.NotificationDTO;
+import com.hifive.bururung.domain.notification.entity.Notification;
+import com.hifive.bururung.domain.notification.repository.INotificationMapper;
+import com.hifive.bururung.domain.notification.repository.INotificationRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationServiceTest {
+
+    @InjectMocks
+    private NotificationService notificationService;
+    
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+    
+    @Mock
+    private INotificationRepository notificationRepository;
+    
+    @Mock
+    private INotificationMapper notificationMapper;
+    
+    // 1. getNotifications()
+    @Test
+    void testGetNotifications() {
+        List<Notification> notifications = mock(List.class);
+        when(notificationRepository.findAll()).thenReturn(notifications);
+        
+        List<Notification> result = notificationService.getNotifications();
+        assertEquals(notifications, result);
+    }
+    
+    // 2. getReadNotifications()
+    @Test
+    void testGetReadNotifications() {
+        Long memberId = 1L;
+        List<NotificationDTO> readList = mock(List.class);
+        when(notificationMapper.getReadNotifications(memberId)).thenReturn(readList);
+        
+        List<NotificationDTO> result = notificationService.getReadNotifications(memberId);
+        assertEquals(readList, result);
+    }
+    
+    // 3. getUnreadNotifications()
+    @Test
+    void testGetUnreadNotifications() {
+        Long memberId = 1L;
+        List<NotificationDTO> unreadList = mock(List.class);
+        when(notificationMapper.getUnreadNotifications(memberId)).thenReturn(unreadList);
+        
+        List<NotificationDTO> result = notificationService.getUnreadNotifications(memberId);
+        assertEquals(unreadList, result);
+    }
+    
+    // 4. getNotificationsBySenderId()
+    @Test
+    void testGetNotificationsBySenderId() {
+        Long senderId = 10L;
+        // 도메인 객체 Notification은 new 대신 @Mock/spy 사용
+        Notification notificationMock = mock(Notification.class);
+        when(notificationMock.getNotificationId()).thenReturn(1L);
+        LocalDateTime createdDate = LocalDateTime.of(2025, 1, 1, 12, 0);
+        when(notificationMock.getCreatedDate()).thenReturn(createdDate);
+        when(notificationMock.getCategory()).thenReturn("CATEGORY");
+        when(notificationMock.getServiceCtg()).thenReturn("SERVICE");
+        when(notificationMock.getContent()).thenReturn("Content");
+        when(notificationMock.getSenderId()).thenReturn(10L);
+        when(notificationMock.getRecipientId()).thenReturn(20L);
+        
+        List<Notification> notificationList = List.of(notificationMock);
+        when(notificationRepository.findAllBySenderIdAndOpenStatusOrderByCreatedDateDesc(senderId, "Y"))
+            .thenReturn(notificationList);
+        
+        List<NotificationDTO> result = notificationService.getNotificationsBySenderId(senderId);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        NotificationDTO dto = result.get(0);
+        assertEquals(1L, dto.getNotificationId());
+        assertEquals(createdDate, dto.getCreatedDate());
+        assertEquals("CATEGORY", dto.getCategory());
+        assertEquals("SERVICE", dto.getServiceCtg());
+        assertEquals("Content", dto.getContent());
+        assertEquals(10L, dto.getSenderId());
+        assertEquals(20L, dto.getRecipientId());
+    }
+    
+    // 5. sendNotification()
+    @Test
+    void testSendNotification() {
+        // 도메인 객체 Notification은 @Mock으로 생성
+        Notification notificationMock = mock(Notification.class);
+        when(notificationMock.getRecipientId()).thenReturn(20L);
+        
+        // stub unread notifications from notificationMapper.getUnreadNotifications()
+        List<NotificationDTO> unreadList = mock(List.class);
+        when(notificationMapper.getUnreadNotifications(20L)).thenReturn(unreadList);
+        
+        notificationService.sendNotification(notificationMock);
+        
+        // verify insertNotification() 호출
+        verify(notificationMapper).insertNotification(notificationMock);
+        // verify that createdDate was set on the notification
+        verify(notificationMock).setCreatedDate(any(LocalDateTime.class));
+        // verify that messagingTemplate.convertAndSend() was called with the correct parameters
+        verify(messagingTemplate).convertAndSend("/topic/notifications", unreadList);
+    }
+    
+    // 6. readNotification()
+    @Test
+    void testReadNotification() {
+        Long notificationId = 5L;
+        Long memberId = 30L;
+        List<NotificationDTO> unreadList = mock(List.class);
+        when(notificationMapper.getUnreadNotifications(memberId)).thenReturn(unreadList);
+        
+        notificationService.readNotification(notificationId, memberId);
+        verify(notificationMapper).updateNotificationToRead(notificationId);
+        verify(messagingTemplate).convertAndSend("/topic/notifications", unreadList);
+    }
+    
+    // 7. deleteNotification()
+    @Test
+    void testDeleteNotification() {
+        Long notificationId = 10L;
+        doNothing().when(notificationMapper).updateNotificationToDelete(notificationId);
+        notificationService.deleteNotification(notificationId);
+        verify(notificationMapper).updateNotificationToDelete(notificationId);
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/payment/controller/PaymentControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/payment/controller/PaymentControllerTest.java
@@ -1,0 +1,98 @@
+package com.hifive.bururung.domain.payment.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
+
+import com.hifive.bururung.domain.credit.service.IMemberCreditService;
+import com.hifive.bururung.domain.payment.dto.ConfirmRequest;
+import com.hifive.bururung.domain.payment.dto.PaymentConfirmResponse;
+import com.hifive.bururung.domain.payment.dto.PaymentRequest;
+import com.hifive.bururung.domain.payment.repository.PaymentRepository;
+import com.hifive.bururung.domain.payment.service.IPaymentService;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentControllerTest {
+
+    @InjectMocks
+    private PaymentController paymentController;
+    
+    @Mock
+    private IPaymentService paymentService;
+    
+    @Mock
+    private IMemberCreditService memberCreditService;
+    
+    @Mock
+    private PaymentRepository paymentRepository;
+    
+    @Mock
+    private PaymentRequest paymentRequest;
+    
+    @Mock
+    private ConfirmRequest confirmRequest;
+    
+    // @AuthenticationPrincipal로 주입될 User 객체를 @Mock으로 생성
+    @Mock
+    private User user;
+    
+    // 1. POST /api/payment/request 테스트
+    @Test
+    void testRequestPayment_Success() {
+        Long paymentId = 100L;
+        when(paymentService.requestPayment(paymentRequest)).thenReturn(paymentId);
+        
+        ResponseEntity<Long> response = paymentController.requestPayment(paymentRequest);
+        
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(paymentId, response.getBody());
+        verify(paymentService).requestPayment(paymentRequest);
+    }
+    
+    // 2. POST /api/payment/confirm 테스트 (정상 케이스)
+    @Test
+    void testConfirmPayment_Success() throws Exception {
+        // User의 username을 "1"로 stubbing하여 memberId = 1L로 변환
+        when(user.getUsername()).thenReturn("1");
+        
+        // ConfirmRequest의 stubbing
+        String paymentKey = "paymentKey123";
+        String orderId = "order456";
+        int price = 1000;
+        when(confirmRequest.getPaymentKey()).thenReturn(paymentKey);
+        when(confirmRequest.getOrderId()).thenReturn(orderId);
+        when(confirmRequest.getPrice()).thenReturn((long) price);
+        
+        // paymentService.verify()가 paymentId를 반환하도록 stubbing
+        Long paymentId = 200L;
+        when(paymentService.verify(paymentKey, orderId, (long) price)).thenReturn(paymentId);
+        
+        // paymentService.requestConfirm()가 PaymentConfirmResponse를 반환하도록 stubbing
+        PaymentConfirmResponse paymentConfirmResponse = mock(PaymentConfirmResponse.class);
+        when(paymentService.requestConfirm(paymentKey, orderId, (long) price)).thenReturn(paymentConfirmResponse);
+        
+        // paymentRepository.findCreditCount() stubbing
+        int creditCount = 50;
+        when(paymentRepository.findCreditCount(paymentId)).thenReturn(creditCount);
+        
+        // Call confirmPayment
+        ResponseEntity<PaymentConfirmResponse> response = paymentController.confirmPayment(user, confirmRequest);
+        
+        // Verify memberCreditService.chargeCredit() 호출 (memberId = 1, creditCount = 50)
+        verify(memberCreditService).chargeCredit(1L, creditCount);
+        
+        // Assert ResponseEntity
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(paymentConfirmResponse, response.getBody());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/payment/service/PaymentServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/payment/service/PaymentServiceTest.java
@@ -1,0 +1,213 @@
+package com.hifive.bururung.domain.payment.service;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import com.hifive.bururung.domain.credit.entity.Credit;
+import com.hifive.bururung.domain.credit.repository.CreditRepository;
+import com.hifive.bururung.domain.member.entity.Member;
+import com.hifive.bururung.domain.member.repository.MemberRepository;
+import com.hifive.bururung.domain.payment.dto.PaymentConfirmResponse;
+import com.hifive.bururung.domain.payment.dto.PaymentRequest;
+import com.hifive.bururung.domain.payment.entity.Payment;
+import com.hifive.bururung.domain.payment.entity.PaymentMethod;
+import com.hifive.bururung.domain.payment.repository.PaymentRepository;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.MemberErrorCode;
+import com.hifive.bururung.global.exception.errorcode.PaymentErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentServiceTest {
+
+    @InjectMocks
+    private PaymentService paymentService;
+    
+    @Mock
+    private PaymentRepository paymentRepository;
+    
+    @Mock
+    private CreditRepository creditRepository;
+    
+    @Mock
+    private MemberRepository memberRepository;
+    
+    // secretKey는 @Value로 주입되므로, 테스트에서 ReflectionTestUtils로 주입
+    @BeforeEach
+    void setUp() {
+        org.springframework.test.util.ReflectionTestUtils.setField(paymentService, "secretKey", "secret");
+    }
+    
+    // --- requestPayment() ---
+    
+    @Test
+    void testRequestPayment_Success() {
+        // PaymentRequest를 @Mock으로 생성
+        PaymentRequest paymentRequest = mock(PaymentRequest.class);
+        when(paymentRequest.getCreditCount()).thenReturn(100);
+        when(paymentRequest.getMemberId()).thenReturn(1L);
+        when(paymentRequest.getOrderId()).thenReturn("order123");
+        when(paymentRequest.getAmount()).thenReturn(5000L);
+        when(paymentRequest.getMethod()).thenReturn(PaymentMethod.CARD);
+        
+        // Credit와 Member 도메인 객체를 @Mock으로 생성
+        Credit creditMock = mock(Credit.class);
+        Member memberMock = mock(Member.class);
+        
+        when(creditRepository.findByCount(100)).thenReturn(Optional.of(creditMock));
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(memberMock));
+        
+        // Payment 객체는 builder() 내부에서 생성되므로, save() 메서드에서 전달받은 객체를 반환하도록 stubbing.
+        // Payment는 도메인 객체이므로 @Spy를 사용하여 생성.
+        Payment paymentSpy = mock(Payment.class, withSettings().defaultAnswer(org.mockito.Answers.CALLS_REAL_METHODS));
+        // stubbing getPaymentId() to return 10L
+        when(paymentSpy.getPaymentId()).thenReturn(10L);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(paymentSpy);
+        
+        Long paymentId = paymentService.requestPayment(paymentRequest);
+        assertEquals(10L, paymentId);
+        
+        // Verify Payment 객체의 필드가 올바르게 설정되었는지 캡처
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository).save(captor.capture());
+        Payment savedPayment = captor.getValue();
+        assertEquals("order123", savedPayment.getOrderId());
+        assertEquals(5000L, savedPayment.getPrice());
+        assertEquals("CARD", savedPayment.getMethod());
+        assertEquals(memberMock, savedPayment.getMember());
+        assertEquals(creditMock, savedPayment.getCredit());
+    }
+    
+    @Test
+    void testRequestPayment_CreditNotFound() {
+        PaymentRequest paymentRequest = mock(PaymentRequest.class);
+        when(paymentRequest.getCreditCount()).thenReturn(100);
+        when(creditRepository.findByCount(100)).thenReturn(Optional.empty());
+        
+        CustomException exception = assertThrows(CustomException.class, () -> 
+            paymentService.requestPayment(paymentRequest)
+        );
+        assertEquals(PaymentErrorCode.CREDIT_NOT_FOUND, exception.getErrorCode());
+    }
+    
+    @Test
+    void testRequestPayment_MemberNotFound() {
+        PaymentRequest paymentRequest = mock(PaymentRequest.class);
+        when(paymentRequest.getCreditCount()).thenReturn(100);
+        Credit creditMock = mock(Credit.class);
+        when(creditRepository.findByCount(100)).thenReturn(Optional.of(creditMock));
+        when(paymentRequest.getMemberId()).thenReturn(1L);
+        when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+        
+        CustomException exception = assertThrows(CustomException.class, () ->
+            paymentService.requestPayment(paymentRequest)
+        );
+        assertEquals(MemberErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+    
+    // --- verify() ---
+    
+    @Test
+    void testVerify_Success() {
+        String orderId = "order123";
+        Long price = 5000L;
+        String paymentKey = "payKey123";
+        
+        Payment paymentSpy = mock(Payment.class, withSettings().defaultAnswer(org.mockito.Answers.CALLS_REAL_METHODS));
+        when(paymentSpy.getPrice()).thenReturn(price);
+        when(paymentSpy.getPaymentId()).thenReturn(20L);
+        when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.of(paymentSpy));
+        
+        Long resultPaymentId = paymentService.verify(paymentKey, orderId, price);
+        assertEquals(20L, resultPaymentId);
+        verify(paymentSpy).setPaymentKey(paymentKey);
+    }
+    
+    @Test
+    void testVerify_PaymentAmountError() {
+        String orderId = "order123";
+        Long expectedPrice = 5000L;
+        Long wrongPrice = 4000L;
+        String paymentKey = "payKey123";
+        
+        Payment paymentMock = mock(Payment.class);
+        when(paymentMock.getPrice()).thenReturn(expectedPrice);
+        when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.of(paymentMock));
+        
+        CustomException exception = assertThrows(CustomException.class, () ->
+            paymentService.verify(paymentKey, orderId, wrongPrice)
+        );
+        assertEquals(PaymentErrorCode.PAYMENT_AMOUNT_ERROR, exception.getErrorCode());
+    }
+    
+    // --- requestConfirm() ---
+    
+    @Test
+    void testRequestConfirm_Success() throws Exception {
+        String paymentKey = "payKey123";
+        String orderId = "order123";
+        Long price = 5000L;
+        
+        // PaymentConfirmResponse를 @Mock으로 생성
+        PaymentConfirmResponse confirmResponseMock = mock(PaymentConfirmResponse.class);
+        when(confirmResponseMock.getStatus()).thenReturn("CONFIRMED");
+        
+        // Payment 객체 (spy)
+        Payment paymentSpy = mock(Payment.class, withSettings().defaultAnswer(org.mockito.Answers.CALLS_REAL_METHODS));
+        when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.of(paymentSpy));
+        
+        // RestTemplate 생성 시 new RestTemplate()을 모의하기 위해 mockConstruction 사용
+        try (MockedConstruction<RestTemplate> restTemplateMocked = mockConstruction(RestTemplate.class, (mock, context) -> {
+            when(mock.postForEntity(anyString(), any(HttpEntity.class), eq(PaymentConfirmResponse.class)))
+                .thenReturn(ResponseEntity.ok(confirmResponseMock));
+        })) {
+            PaymentConfirmResponse result = paymentService.requestConfirm(paymentKey, orderId, price);
+            // verify that payment.changeState() was called with "CONFIRMED"
+            verify(paymentSpy).changeState("CONFIRMED");
+            assertEquals(confirmResponseMock, result);
+            
+            // Optional: 캡처하여 HttpEntity 내부의 JSON 객체나 헤더를 검증 가능 (생략)
+        }
+    }
+    
+    @Test
+    void testRequestConfirm_PaymentNotFound() {
+        String paymentKey = "payKey123";
+        String orderId = "order123";
+        Long price = 5000L;
+        
+        PaymentConfirmResponse confirmResponseMock = mock(PaymentConfirmResponse.class);
+        when(confirmResponseMock.getStatus()).thenReturn("CONFIRMED");
+        
+        try (MockedConstruction<RestTemplate> restTemplateMocked = mockConstruction(RestTemplate.class, (mock, context) -> {
+            when(mock.postForEntity(anyString(), any(HttpEntity.class), eq(PaymentConfirmResponse.class)))
+                .thenReturn(ResponseEntity.ok(confirmResponseMock));
+        })) {
+            when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.empty());
+            CustomException exception = assertThrows(CustomException.class, () ->
+                paymentService.requestConfirm(paymentKey, orderId, price)
+            );
+            assertEquals(PaymentErrorCode.PAYMENT_NOT_FOUND, exception.getErrorCode());
+        }
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/statistics/controller/StatisticsControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/statistics/controller/StatisticsControllerTest.java
@@ -1,0 +1,81 @@
+package com.hifive.bururung.domain.statistics.controller;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.statistics.dto.AgeGroupRatioResponse;
+import com.hifive.bururung.domain.statistics.dto.GenderRatioResponse;
+import com.hifive.bururung.domain.statistics.dto.MemberNameWithRateResponse;
+import com.hifive.bururung.domain.statistics.dto.MonthlyNewMemberResponse;
+import com.hifive.bururung.domain.statistics.service.IStatisticsService;
+
+@ExtendWith(MockitoExtension.class)
+public class StatisticsControllerTest {
+
+    @InjectMocks
+    private StatisticsController statisticsController;
+
+    @Mock
+    private IStatisticsService iStatisticsService;
+
+    @Test
+    void testGetGenderRatio() {
+        // given
+        List<GenderRatioResponse> dummyList = Collections.emptyList();
+        when(iStatisticsService.getGenderRatio()).thenReturn(dummyList);
+
+        // when
+        List<GenderRatioResponse> result = statisticsController.getGenderRatio();
+
+        // then
+        assertSame(dummyList, result);
+    }
+
+    @Test
+    void testGetAgeGroupRatio() {
+        // given
+        List<AgeGroupRatioResponse> dummyList = Collections.emptyList();
+        when(iStatisticsService.getAgeGroupRatio()).thenReturn(dummyList);
+
+        // when
+        List<AgeGroupRatioResponse> result = statisticsController.getAgeGroupRatio();
+
+        // then
+        assertSame(dummyList, result);
+    }
+
+    @Test
+    void testGetMonthlyNewMemberCount() {
+        // given
+        List<MonthlyNewMemberResponse> dummyList = Collections.emptyList();
+        when(iStatisticsService.getMonthlyNewMemberCount()).thenReturn(dummyList);
+
+        // when
+        List<MonthlyNewMemberResponse> result = statisticsController.getMonthlyNewMemberCount();
+
+        // then
+        assertSame(dummyList, result);
+    }
+
+    @Test
+    void testGetMembersByRatingDesc() {
+        // given
+        List<MemberNameWithRateResponse> dummyList = Collections.emptyList();
+        when(iStatisticsService.getMembersByRatingDesc()).thenReturn(dummyList);
+
+        // when
+        List<MemberNameWithRateResponse> result = statisticsController.getMembersByRatingDesc();
+
+        // then
+        assertSame(dummyList, result);
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/statistics/service/StatisticsServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/statistics/service/StatisticsServiceTest.java
@@ -1,0 +1,104 @@
+package com.hifive.bururung.domain.statistics.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.statistics.dto.AgeGroupRatioResponse;
+import com.hifive.bururung.domain.statistics.dto.GenderRatioResponse;
+import com.hifive.bururung.domain.statistics.dto.MemberNameWithRateResponse;
+import com.hifive.bururung.domain.statistics.dto.MonthlyNewMemberResponse;
+import com.hifive.bururung.domain.statistics.repository.IStatisticsMapper;
+
+@ExtendWith(MockitoExtension.class)
+public class StatisticsServiceTest {
+
+    @InjectMocks
+    private StatisticsService statisticsService;
+    
+    @Mock
+    private IStatisticsMapper iStatisticsMapper;
+    
+    // 도메인 객체들은 new 대신 @Mock을 사용하여 생성
+    @Mock
+    private GenderRatioResponse genderResponse1;
+    
+    @Mock
+    private GenderRatioResponse genderResponse2;
+    
+    @Mock
+    private AgeGroupRatioResponse ageGroupResponse;
+    
+    @Mock
+    private MonthlyNewMemberResponse monthlyNewMemberResponse;
+    
+    @Mock
+    private MemberNameWithRateResponse memberNameWithRateResponse;
+    
+    // 1. getGenderRatio() 테스트
+    @Test
+    void testGetGenderRatio() {
+        // stubbing: 첫번째 객체: 남자, 60건, 두번째 객체: 여자, 40건
+        when(genderResponse1.getCount()).thenReturn(60);
+        when(genderResponse1.getGender()).thenReturn("M");
+        
+        when(genderResponse2.getCount()).thenReturn(40);
+        when(genderResponse2.getGender()).thenReturn("F");
+        
+        // iStatisticsMapper.getGenderCount()가 위 두 객체를 포함하는 리스트를 반환하도록 stubbing
+        when(iStatisticsMapper.getGenderCount()).thenReturn(List.of(genderResponse1, genderResponse2));
+        
+        // 호출
+        List<GenderRatioResponse> result = statisticsService.getGenderRatio();
+        
+        // 총합: 100
+        assertEquals(2, result.size());
+        GenderRatioResponse res1 = result.get(0);
+        GenderRatioResponse res2 = result.get(1);
+        
+        // 첫번째 객체: "M" → "남자", 계산: 60 * 100 / 100 = 60
+        assertEquals(60, res1.getCount());
+        assertEquals("남자", res1.getGender());
+        
+        // 두번째 객체: "F" → "여자", 계산: 40 * 100 / 100 = 40
+        assertEquals(40, res2.getCount());
+        assertEquals("여자", res2.getGender());
+    }
+    
+    // 2. getAgeGroupRatio() 테스트
+    @Test
+    void testGetAgeGroupRatio() {
+        List<AgeGroupRatioResponse> expected = List.of(ageGroupResponse);
+        when(iStatisticsMapper.getAgeGroupRatio()).thenReturn(expected);
+        
+        List<AgeGroupRatioResponse> result = statisticsService.getAgeGroupRatio();
+        assertEquals(expected, result);
+    }
+    
+    // 3. getMonthlyNewMemberCount() 테스트
+    @Test
+    void testGetMonthlyNewMemberCount() {
+        List<MonthlyNewMemberResponse> expected = List.of(monthlyNewMemberResponse);
+        when(iStatisticsMapper.getMonthlyNewMemberCount()).thenReturn(expected);
+        
+        List<MonthlyNewMemberResponse> result = statisticsService.getMonthlyNewMemberCount();
+        assertEquals(expected, result);
+    }
+    
+    // 4. getMembersByRatingDesc() 테스트
+    @Test
+    void testGetMembersByRatingDesc() {
+        List<MemberNameWithRateResponse> expected = List.of(memberNameWithRateResponse);
+        when(iStatisticsMapper.getMembersByRatingDesc()).thenReturn(expected);
+        
+        List<MemberNameWithRateResponse> result = statisticsService.getMembersByRatingDesc();
+        assertEquals(expected, result);
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/taxi/controller/TaxiShareControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/taxi/controller/TaxiShareControllerTest.java
@@ -1,0 +1,183 @@
+package com.hifive.bururung.domain.taxi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.hifive.bururung.domain.member.entity.Member;
+import com.hifive.bururung.domain.member.service.IMemberService;
+import com.hifive.bururung.domain.notification.entity.Notification;
+import com.hifive.bururung.domain.notification.service.INotificationService;
+import com.hifive.bururung.domain.taxi.dto.LatLng;
+import com.hifive.bururung.domain.taxi.dto.TaxiShareJoinRequest;
+import com.hifive.bururung.domain.taxi.dto.TaxiShareResponse;
+import com.hifive.bururung.domain.taxi.entity.TaxiShare;
+import com.hifive.bururung.domain.taxi.service.ITaxiShareJoinService;
+import com.hifive.bururung.domain.taxi.service.ITaxiShareService;
+import com.hifive.bururung.domain.taxi.util.TaxiShareJoinAction;
+import com.hifive.bururung.global.common.NearbyLocationFinder;
+
+@ExtendWith(MockitoExtension.class)
+public class TaxiShareControllerTest {
+
+    @InjectMocks
+    private TaxiShareController taxiShareController;
+    
+    @Mock
+    private ITaxiShareService taxiShareService;
+    
+    @Mock
+    private ITaxiShareJoinService taxiShareJoinService;
+    
+    @Mock
+    private IMemberService memberService;
+    
+    @Mock
+    private INotificationService notificationService;
+    
+    // 1. POST /api/taxi/insert
+    @Test
+    void testInsertTaxiShare() {
+        // TaxiShare 도메인 객체는 @Mock으로 생성
+        TaxiShare taxiShareMock = mock(TaxiShare.class);
+        
+        // insertTaxiShare() 호출
+        ResponseEntity<Void> response = taxiShareController.insertTaxiShare(taxiShareMock);
+        
+        // taxiShareService.insertTaxiShare() 호출 여부 검증
+        verify(taxiShareService).insertTaxiShare(taxiShareMock);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    }
+    
+    // 2. POST /api/taxi/list - target == null (날짜로만 검색)
+    @Test
+    void testGetTaxiShareByPickupTimeAndLatLng_TargetNull() {
+        String pickupTime = "2025-02-14T06:00";
+        List<TaxiShareResponse> taxiShareResponseList = mock(List.class);
+        when(taxiShareService.getTaxiShareByPickupTime(pickupTime)).thenReturn(taxiShareResponseList);
+        
+        ResponseEntity<List<TaxiShareResponse>> response = taxiShareController.getTaxiShareByPickupTimeAndLatLng(pickupTime, null);
+        
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(taxiShareResponseList, response.getBody());
+    }
+    
+    // 3. POST /api/taxi/list - target != null (날짜+위치 검색)
+    @Test
+    void testGetTaxiShareByPickupTimeAndLatLng_WithTarget() {
+        String pickupTime = "2025-02-14T06:00";
+        // 모의 TaxiShareResponse 목록 생성
+        TaxiShareResponse tsResponse1 = mock(TaxiShareResponse.class);
+        TaxiShareResponse tsResponse2 = mock(TaxiShareResponse.class);
+        when(tsResponse1.getLatitudePL()).thenReturn(10.0);
+        when(tsResponse1.getLongitudePL()).thenReturn(20.0);
+        when(tsResponse2.getLatitudePL()).thenReturn(30.0);
+        when(tsResponse2.getLongitudePL()).thenReturn(40.0);
+        List<TaxiShareResponse> fullList = List.of(tsResponse1, tsResponse2);
+        when(taxiShareService.getTaxiShareByPickupTime(pickupTime)).thenReturn(fullList);
+        
+        // 타겟 위치 (목 객체)
+        LatLng target = mock(LatLng.class);
+        when(target.getLat()).thenReturn(10.0);
+        when(target.getLng()).thenReturn(20.0);
+        
+        // allLocations: 리스트 생성 로직은 컨트롤러 내부에서 new ArrayList<>() 사용됨
+        // nearbyLocations: 모의 NearbyLocationFinder.findNearbyLocations()를 통해 제어
+        LatLng nearbyLatLng = mock(LatLng.class);
+        when(nearbyLatLng.getLat()).thenReturn(10.0);
+        when(nearbyLatLng.getLng()).thenReturn(20.0);
+        List<LatLng> nearbyLocations = List.of(nearbyLatLng);
+        
+        // Mock static 메서드 NearbyLocationFinder.findNearbyLocations()
+        try (MockedStatic<NearbyLocationFinder> nearbyFinderMock = mockStatic(NearbyLocationFinder.class)) {
+            nearbyFinderMock.when(() -> NearbyLocationFinder.findNearbyLocations(eq(target), any()))
+                             .thenReturn(nearbyLocations);
+            
+            ResponseEntity<List<TaxiShareResponse>> response = taxiShareController.getTaxiShareByPickupTimeAndLatLng(pickupTime, target);
+            
+            // tsResponse1의 좌표와 nearbyLocations 일치하므로 결과에 포함되어야 함.
+            List<TaxiShareResponse> resultList = response.getBody();
+            assertNotNull(resultList);
+            assertEquals(1, resultList.size());
+            assertEquals(tsResponse1, resultList.get(0));
+        }
+    }
+    
+    // 4. GET /api/taxi/detail/{taxiShareId}
+    @Test
+    void testGetTaxiShareById() {
+        Long taxiShareId = 100L;
+        TaxiShareResponse taxiShareResponseMock = mock(TaxiShareResponse.class);
+        when(taxiShareService.getTaxiShareById(taxiShareId)).thenReturn(taxiShareResponseMock);
+        
+        ResponseEntity<TaxiShareResponse> response = taxiShareController.getTaxiShareById(taxiShareId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(taxiShareResponseMock, response.getBody());
+    }
+    
+    // 5. POST /api/taxi/delete
+    @Test
+    void testDeleteTaxiShare() {
+        // 모의 TaxiShareJoinRequest 생성
+        TaxiShareJoinRequest joinRequest = mock(TaxiShareJoinRequest.class);
+        // 택시 공유 ID 및 삭제 요청 회원 ID stubbing
+        Long taxiShareId = 200L;
+        Long requesterMemberId = 10L;  // 삭제 요청한 사람
+        when(joinRequest.getTaxiShareId()).thenReturn(taxiShareId);
+        when(joinRequest.getMemberId()).thenReturn(requesterMemberId);
+        
+        // 모의 TaxiShareResponse 생성 (삭제되는 게시글 작성자 ID)
+        TaxiShareResponse taxiShareResponseMock = mock(TaxiShareResponse.class);
+        Long actualOwnerId = 5L;
+        when(taxiShareResponseMock.getMemberId()).thenReturn(actualOwnerId);
+        when(taxiShareService.getTaxiShareById(taxiShareId)).thenReturn(taxiShareResponseMock);
+        
+        // 택시 공유에 신청한 멤버 목록 stubbing (예: 2명의 참가자)
+        List<Long> participantMemberIds = List.of(20L, 30L);
+        when(taxiShareJoinService.getMemberIdByTaxiShareId(taxiShareId)).thenReturn(participantMemberIds);
+        
+        // 각 참가자의 Member 객체를 모의(@Mock)로 생성
+        Member participant1 = mock(Member.class);
+        Member participant2 = mock(Member.class);
+        when(memberService.findByMemberId(20L)).thenReturn(participant1);
+        when(memberService.findByMemberId(30L)).thenReturn(participant2);
+        
+        // static 메서드 TaxiShareJoinAction.getTaxiShareDeleteNotiInfo()를 모의
+        Notification notificationMock = mock(Notification.class);
+        try (MockedStatic<TaxiShareJoinAction> taxiShareJoinActionMock = mockStatic(TaxiShareJoinAction.class)) {
+            taxiShareJoinActionMock.when(() ->
+                TaxiShareJoinAction.getTaxiShareDeleteNotiInfo(taxiShareResponseMock, joinRequest, participant1)
+            ).thenReturn(notificationMock);
+            taxiShareJoinActionMock.when(() ->
+                TaxiShareJoinAction.getTaxiShareDeleteNotiInfo(taxiShareResponseMock, joinRequest, participant2)
+            ).thenReturn(notificationMock);
+            
+            // deleteTaxiShare() 호출
+            ResponseEntity<Void> response = taxiShareController.deleteTaxiShare(joinRequest);
+            
+            // Verify: notificationService.sendNotification()가 각 참가자에 대해 호출
+            verify(notificationService, times(2)).sendNotification(notificationMock);
+            // Verify: taxiShareService.deleteTaxiShare(joinRequest) 호출
+            verify(taxiShareService).deleteTaxiShare(joinRequest);
+            
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+        }
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/taxi/controller/TaxiShareJoinControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/taxi/controller/TaxiShareJoinControllerTest.java
@@ -1,0 +1,133 @@
+package com.hifive.bururung.domain.taxi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.hifive.bururung.domain.member.entity.Member;
+import com.hifive.bururung.domain.member.service.IMemberService;
+import com.hifive.bururung.domain.notification.entity.Notification;
+import com.hifive.bururung.domain.notification.service.INotificationService;
+import com.hifive.bururung.domain.taxi.dto.TaxiShareJoinRequest;
+import com.hifive.bururung.domain.taxi.dto.TaxiShareResponse;
+import com.hifive.bururung.domain.taxi.service.ITaxiShareJoinService;
+import com.hifive.bururung.domain.taxi.service.ITaxiShareService;
+import com.hifive.bururung.domain.taxi.util.TaxiShareJoinAction;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.TaxiShareJoinErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+public class TaxiShareJoinControllerTest {
+
+    @InjectMocks
+    private TaxiShareJoinController taxiShareJoinController;
+    
+    @Mock
+    private ITaxiShareJoinService taxiShareJoinService;
+    
+    @Mock
+    private ITaxiShareService taxiShareService;
+    
+    @Mock
+    private INotificationService notificationService;
+    
+    @Mock
+    private IMemberService memberService;
+    
+    // 1. GET /api/taxi/join/count/{taxiShareId}
+    @Test
+    void testGetJoinCountByTaxiShareId() {
+        Long taxiShareId = 100L;
+        int joinCount = 5;
+        when(taxiShareJoinService.getJoinCountByTaxiShareId(taxiShareId)).thenReturn(joinCount);
+        
+        ResponseEntity<Integer> response = taxiShareJoinController.getJoinCountByTaxiShareId(taxiShareId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(joinCount, response.getBody());
+    }
+    
+    // 2. POST /api/taxi/join/insert - 성공 케이스: duplCnt < 1 && isHost < 1
+    @Test
+    void testInsertTaxiShareJoin_Success() {
+        // 모의 TaxiShareJoinRequest 생성 (@Mock 사용)
+        TaxiShareJoinRequest joinRequest = mock(TaxiShareJoinRequest.class);
+        // stubbing: getDuplCnt, getMemberId, getTaxiShareId
+        when(taxiShareJoinService.getDuplCntByTaxiShareIdAndMemberId(joinRequest)).thenReturn(0);
+        when(taxiShareService.getCountTaxsiShareByIdAndMemberId(joinRequest)).thenReturn(0);
+        
+        // stubbing: 택시 공유 정보
+        TaxiShareResponse taxiShareResponseMock = mock(TaxiShareResponse.class);
+        when(joinRequest.getTaxiShareId()).thenReturn(200L);
+        when(taxiShareService.getTaxiShareById(200L)).thenReturn(taxiShareResponseMock);
+        
+        // stubbing: hostInfo와 participantInfo (둘 다 같은 memberId로 처리)
+        Long memberId = 10L;
+        when(joinRequest.getMemberId()).thenReturn(memberId);
+        Member hostInfo = mock(Member.class);
+        Member participantInfo = mock(Member.class);
+        when(memberService.findByMemberId(memberId)).thenReturn(hostInfo, participantInfo);
+        
+        // stubbing: static 메서드 TaxiShareJoinAction.getTaxiShareJoinNotiInfo()를 목으로 처리
+        Notification notificationMock = mock(Notification.class);
+        try (MockedStatic<TaxiShareJoinAction> staticMock = mockStatic(TaxiShareJoinAction.class)) {
+            staticMock.when(() -> TaxiShareJoinAction.getTaxiShareJoinNotiInfo(taxiShareResponseMock, joinRequest, participantInfo, hostInfo, 1))
+                      .thenReturn(notificationMock);
+            staticMock.when(() -> TaxiShareJoinAction.getTaxiShareJoinNotiInfo(taxiShareResponseMock, joinRequest, participantInfo, hostInfo, 2))
+                      .thenReturn(notificationMock);
+            
+            // stubbing: insertCreditByTaxi()와 insertTaxiShareJoin()는 void
+            doNothing().when(taxiShareJoinService).insertCreditByTaxi(2, memberId);
+            doNothing().when(taxiShareJoinService).insertTaxiShareJoin(joinRequest);
+            doNothing().when(notificationService).sendNotification(notificationMock);
+            
+            ResponseEntity<Void> response = taxiShareJoinController.insertTaxiShareJoin(joinRequest);
+            assertEquals(HttpStatus.CREATED, response.getStatusCode());
+            
+            // Verify: 두 번 알림 전송, 크레딧 차감, 참여 insert 호출
+            verify(taxiShareJoinService).insertCreditByTaxi(2, memberId);
+            verify(notificationService, times(2)).sendNotification(notificationMock);
+            verify(taxiShareJoinService).insertTaxiShareJoin(joinRequest);
+        }
+    }
+    
+    // 3. POST /api/taxi/join/insert - 실패: duplicate join attempt (duplCnt >= 1)
+    @Test
+    void testInsertTaxiShareJoin_DuplicateJoin() {
+        TaxiShareJoinRequest joinRequest = mock(TaxiShareJoinRequest.class);
+        when(taxiShareJoinService.getDuplCntByTaxiShareIdAndMemberId(joinRequest)).thenReturn(1);
+        
+        CustomException exception = assertThrows(CustomException.class, () -> 
+            taxiShareJoinController.insertTaxiShareJoin(joinRequest)
+        );
+        assertEquals(TaxiShareJoinErrorCode.DUPLICATE_JOIN_ATTEMPT, exception.getErrorCode());
+    }
+    
+    // 4. POST /api/taxi/join/insert - 실패: host joining own share (isHost >= 1)
+    @Test
+    void testInsertTaxiShareJoin_HostJoinNotAllowed() {
+        TaxiShareJoinRequest joinRequest = mock(TaxiShareJoinRequest.class);
+        // 중복 참여 없음
+        when(taxiShareJoinService.getDuplCntByTaxiShareIdAndMemberId(joinRequest)).thenReturn(0);
+        // 호스트인 경우: isHost >= 1
+        when(taxiShareService.getCountTaxsiShareByIdAndMemberId(joinRequest)).thenReturn(1);
+        
+        CustomException exception = assertThrows(CustomException.class, () ->
+            taxiShareJoinController.insertTaxiShareJoin(joinRequest)
+        );
+        assertEquals(TaxiShareJoinErrorCode.CANNOT_JOIN_OWN_SHARE, exception.getErrorCode());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/taxi/service/TaxiShareJoinServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/taxi/service/TaxiShareJoinServiceTest.java
@@ -1,0 +1,173 @@
+package com.hifive.bururung.domain.taxi.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.taxi.dto.TaxiShareJoinRequest;
+import com.hifive.bururung.domain.taxi.repository.ITaxiShareJoinRepository;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.TaxiShareJoinErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+public class TaxiShareJoinServiceTest {
+
+    @InjectMocks
+    private TaxiShareJoinService taxiShareJoinService;
+    
+    @Mock
+    private ITaxiShareJoinRepository taxiShareJoinRepository;
+    
+    // 1. getJoinCountByTaxiShareId() 성공 케이스
+    @Test
+    void testGetJoinCountByTaxiShareId_Success() {
+        Long taxiShareId = 1L;
+        when(taxiShareJoinRepository.getJoinCountByTaxiShareId(taxiShareId)).thenReturn(5);
+        
+        int result = taxiShareJoinService.getJoinCountByTaxiShareId(taxiShareId);
+        assertEquals(5, result);
+    }
+    
+    // 1. getJoinCountByTaxiShareId() 예외 케이스
+    @Test
+    void testGetJoinCountByTaxiShareId_Exception() {
+        Long taxiShareId = 1L;
+        when(taxiShareJoinRepository.getJoinCountByTaxiShareId(taxiShareId))
+            .thenThrow(new RuntimeException("DB error"));
+        
+        CustomException exception = assertThrows(CustomException.class, () ->
+            taxiShareJoinService.getJoinCountByTaxiShareId(taxiShareId)
+        );
+        assertEquals(TaxiShareJoinErrorCode.JOIN_NOT_FOUND, exception.getErrorCode());
+    }
+    
+    // 2. insertTaxiShareJoin() 성공 케이스 (예외 발생하지 않음)
+    @Test
+    void testInsertTaxiShareJoin_Success() {
+        TaxiShareJoinRequest joinRequest = mock(TaxiShareJoinRequest.class);
+        // 아무런 예외도 발생하지 않는 상황 stubbing
+        doNothing().when(taxiShareJoinRepository).insertTaxiShareJoin(joinRequest);
+        
+        // 호출 시 예외가 발생하지 않아야 함
+        assertDoesNotThrow(() -> taxiShareJoinService.insertTaxiShareJoin(joinRequest));
+        verify(taxiShareJoinRepository).insertTaxiShareJoin(joinRequest);
+    }
+    
+    // 3. getDuplCntByTaxiShareIdAndMemberId()
+    @Test
+    void testGetDuplCntByTaxiShareIdAndMemberId() {
+        TaxiShareJoinRequest joinRequest = mock(TaxiShareJoinRequest.class);
+        when(taxiShareJoinRepository.getDuplCntByTaxiShareIdAndMemberId(joinRequest)).thenReturn(0);
+        
+        int result = taxiShareJoinService.getDuplCntByTaxiShareIdAndMemberId(joinRequest);
+        assertEquals(0, result);
+    }
+    
+    // 4. getMemberIdByTaxiShareId()
+    @Test
+    void testGetMemberIdByTaxiShareId() {
+        Long taxiShareId = 2L;
+        List<Long> memberIds = List.of(10L, 20L, 30L);
+        when(taxiShareJoinRepository.getMemberIdByTaxiShareId(taxiShareId)).thenReturn(memberIds);
+        
+        List<Long> result = taxiShareJoinService.getMemberIdByTaxiShareId(taxiShareId);
+        assertEquals(memberIds, result);
+    }
+    
+    // 5. deleteTaxiShareJoinByTaxiShareId() 성공 케이스
+    @Test
+    void testDeleteTaxiShareJoinByTaxiShareId_Success() {
+        Long taxiShareId = 3L;
+        doNothing().when(taxiShareJoinRepository).deleteTaxiShareJoinById(taxiShareId);
+        
+        assertDoesNotThrow(() -> taxiShareJoinService.deleteTaxiShareJoinByTaxiShareId(taxiShareId));
+        verify(taxiShareJoinRepository).deleteTaxiShareJoinById(taxiShareId);
+    }
+    
+    // 5. deleteTaxiShareJoinByTaxiShareId() 예외 케이스
+    @Test
+    void testDeleteTaxiShareJoinByTaxiShareId_Exception() {
+        Long taxiShareId = 3L;
+        doThrow(new RuntimeException("Delete error")).when(taxiShareJoinRepository).deleteTaxiShareJoinById(taxiShareId);
+        
+        // 메서드 내에서 예외를 catch하므로, 호출 시 예외가 발생하지 않아야 함.
+        assertDoesNotThrow(() -> taxiShareJoinService.deleteTaxiShareJoinByTaxiShareId(taxiShareId));
+        verify(taxiShareJoinRepository).deleteTaxiShareJoinById(taxiShareId);
+    }
+    
+    // 6. findLeftoverCredit()
+    @Test
+    void testFindLeftoverCredit() {
+        Long memberId = 5L;
+        when(taxiShareJoinRepository.findLeftoverCredit(memberId)).thenReturn(10);
+        
+        int result = taxiShareJoinService.findLeftoverCredit(memberId);
+        assertEquals(10, result);
+    }
+    
+    // 7. insertCreditByTaxi() 성공 케이스
+    @Test
+    void testInsertCreditByTaxi_Success() {
+        Long memberId = 5L;
+        int count = 3;
+        when(taxiShareJoinRepository.findLeftoverCredit(memberId)).thenReturn(5);
+        doNothing().when(taxiShareJoinRepository).insertCreditByTaxi(count, memberId);
+        
+        // 호출 시 예외 발생 없이 진행되어야 함.
+        assertDoesNotThrow(() -> taxiShareJoinService.insertCreditByTaxi(count, memberId));
+        verify(taxiShareJoinRepository).insertCreditByTaxi(count, memberId);
+    }
+    
+    // 7. insertCreditByTaxi() 실패 케이스
+    @Test
+    void testInsertCreditByTaxi_Failure() {
+        Long memberId = 5L;
+        int count = 10;
+        when(taxiShareJoinRepository.findLeftoverCredit(memberId)).thenReturn(5);
+        
+        CustomException exception = assertThrows(CustomException.class, () ->
+            taxiShareJoinService.insertCreditByTaxi(count, memberId)
+        );
+        assertEquals(TaxiShareJoinErrorCode.CREDIT_DEDUCTED_FAILED, exception.getErrorCode());
+        verify(taxiShareJoinRepository, never()).insertCreditByTaxi(anyInt(), anyLong());
+    }
+    
+    // 8. getCarShareCountByMemberIdAndSysdate() 성공 케이스
+    @Test
+    void testGetCarShareCountByMemberIdAndSysdate_Success() {
+        List<HashMap<String, Object>> expectedList = mock(List.class);
+        when(taxiShareJoinRepository.getCarShareCountByMemberIdAndSysdate()).thenReturn(expectedList);
+        
+        List<HashMap<String, Object>> result = taxiShareJoinService.getCarShareCountByMemberIdAndSysdate();
+        assertEquals(expectedList, result);
+    }
+    
+    // 8. getCarShareCountByMemberIdAndSysdate() 예외 케이스
+    @Test
+    void testGetCarShareCountByMemberIdAndSysdate_Exception() {
+        when(taxiShareJoinRepository.getCarShareCountByMemberIdAndSysdate())
+            .thenThrow(new RuntimeException("Query error"));
+        
+        CustomException exception = assertThrows(CustomException.class, () ->
+            taxiShareJoinService.getCarShareCountByMemberIdAndSysdate()
+        );
+        assertEquals(TaxiShareJoinErrorCode.CAR_SHARE_SYSDATE_NOT_FOUND, exception.getErrorCode());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/taxi/service/TaxiShareServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/taxi/service/TaxiShareServiceTest.java
@@ -1,0 +1,122 @@
+package com.hifive.bururung.domain.taxi.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.taxi.dto.TaxiShareJoinRequest;
+import com.hifive.bururung.domain.taxi.dto.TaxiShareResponse;
+import com.hifive.bururung.domain.taxi.entity.TaxiShare;
+import com.hifive.bururung.domain.taxi.repository.ITaxiShareJoinRepository;
+import com.hifive.bururung.domain.taxi.repository.ITaxiShareRepository;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.TaxiShareErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+public class TaxiShareServiceTest {
+
+    @InjectMocks
+    private TaxiShareService taxiShareService;
+    
+    @Mock
+    private ITaxiShareRepository taxiShareRepository;
+    
+    @Mock
+    private ITaxiShareJoinRepository taxiShareJoinRepository;
+    
+    // 1. findAll() 테스트
+    @Test
+    void testFindAll() {
+        List<TaxiShare> taxiShareList = mock(List.class);
+        when(taxiShareRepository.findAll()).thenReturn(taxiShareList);
+        
+        List<TaxiShare> result = taxiShareService.findAll();
+        assertEquals(taxiShareList, result);
+    }
+    
+    // 2. insertTaxiShare() 테스트
+    @Test
+    void testInsertTaxiShare_Success() {
+        // TaxiShare 도메인 객체는 @Mock으로 생성
+        TaxiShare taxiShare = mock(TaxiShare.class);
+        doNothing().when(taxiShareRepository).insertTaxiShare(taxiShare);
+        
+        // 예외 없이 호출되어야 함
+        assertDoesNotThrow(() -> taxiShareService.insertTaxiShare(taxiShare));
+        verify(taxiShareRepository).insertTaxiShare(taxiShare);
+    }
+    
+    // 3. getTaxiShareByPickupTime() 테스트
+    @Test
+    void testGetTaxiShareByPickupTime() {
+        String pickupTime = "2025-02-14T06:00";
+        List<TaxiShareResponse> responseList = mock(List.class);
+        when(taxiShareRepository.getTaxiShareByPickupTime(pickupTime)).thenReturn(responseList);
+        
+        List<TaxiShareResponse> result = taxiShareService.getTaxiShareByPickupTime(pickupTime);
+        assertEquals(responseList, result);
+    }
+    
+    // 4. getTaxiShareById() 테스트
+    @Test
+    void testGetTaxiShareById() {
+        Long taxiShareId = 100L;
+        TaxiShareResponse response = mock(TaxiShareResponse.class);
+        when(taxiShareRepository.getTaxiShareById(taxiShareId)).thenReturn(response);
+        
+        TaxiShareResponse result = taxiShareService.getTaxiShareById(taxiShareId);
+        assertEquals(response, result);
+    }
+    
+    // 5. getCountTaxsiShareByIdAndMemberId() 테스트
+    @Test
+    void testGetCountTaxsiShareByIdAndMemberId() {
+        TaxiShareJoinRequest joinRequest = mock(TaxiShareJoinRequest.class);
+        when(taxiShareRepository.getCountTaxsiShareByIdAndMemberId(joinRequest)).thenReturn(3);
+        
+        int result = taxiShareService.getCountTaxsiShareByIdAndMemberId(joinRequest);
+        assertEquals(3, result);
+    }
+    
+    // 6. deleteTaxiShare() 테스트 - 성공 케이스
+    @Test
+    void testDeleteTaxiShare_Success() {
+        TaxiShareJoinRequest joinRequest = mock(TaxiShareJoinRequest.class);
+        Long taxiShareId = 200L;
+        when(joinRequest.getTaxiShareId()).thenReturn(taxiShareId);
+        doNothing().when(taxiShareJoinRepository).deleteTaxiShareJoinByTaxiShareId(taxiShareId);
+        when(taxiShareRepository.deleteTaxiShare(joinRequest)).thenReturn(1);
+        
+        int result = taxiShareService.deleteTaxiShare(joinRequest);
+        assertEquals(1, result);
+        verify(taxiShareJoinRepository).deleteTaxiShareJoinByTaxiShareId(taxiShareId);
+        verify(taxiShareRepository).deleteTaxiShare(joinRequest);
+    }
+    
+    // 6. deleteTaxiShare() 테스트 - 예외 케이스
+    @Test
+    void testDeleteTaxiShare_Exception() {
+        TaxiShareJoinRequest joinRequest = mock(TaxiShareJoinRequest.class);
+        Long taxiShareId = 200L;
+        when(joinRequest.getTaxiShareId()).thenReturn(taxiShareId);
+        doNothing().when(taxiShareJoinRepository).deleteTaxiShareJoinByTaxiShareId(taxiShareId);
+        when(taxiShareRepository.deleteTaxiShare(joinRequest)).thenThrow(new RuntimeException("Delete error"));
+        
+        CustomException exception = assertThrows(CustomException.class, () -> 
+            taxiShareService.deleteTaxiShare(joinRequest)
+        );
+        assertEquals(TaxiShareErrorCode.TAXI_SHARE_DELETE_FAILED, exception.getErrorCode());
+    }
+}

--- a/bururung/src/test/java/com/hifive/bururung/domain/taxi/util/TaxiShareJoinActionTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/taxi/util/TaxiShareJoinActionTest.java
@@ -1,0 +1,131 @@
+package com.hifive.bururung.domain.taxi.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.sql.Date;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hifive.bururung.domain.member.entity.Member;
+import com.hifive.bururung.domain.notification.entity.Notification;
+import com.hifive.bururung.domain.taxi.dto.TaxiShareJoinRequest;
+import com.hifive.bururung.domain.taxi.dto.TaxiShareResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class TaxiShareJoinActionTest {
+
+    @Mock
+    private TaxiShareResponse taxiShareResponse;
+    
+    @Mock
+    private TaxiShareJoinRequest taxiShareJoinRequest;
+    
+    @Mock
+    private Member participantInfo;
+    
+    @Mock
+    private Member hostInfo;
+    
+    @Mock
+    private Date date = new Date(10);
+    
+    // 테스트: 참여 알림 (type == 1)
+    @Test
+    void testGetTaxiShareJoinNotiInfo_Type1() {
+        // Stubbing for hostInfo
+        when(hostInfo.getNickname()).thenReturn("HostNick");
+        
+        // Stubbing for taxiShareResponse
+        when(taxiShareResponse.getPickupTime()).thenReturn(date);
+        when(taxiShareResponse.getPickupTimeOnly()).thenReturn("AM");
+        when(taxiShareResponse.getPickupLocation()).thenReturn("LocationA");
+        when(taxiShareResponse.getDestination()).thenReturn("DestinationB");
+        when(taxiShareResponse.getOpenchatLink()).thenReturn("http://openchat.link");
+        when(taxiShareResponse.getOpenchatCode()).thenReturn("OC123");
+        
+        // Stubbing for taxiShareJoinRequest
+        when(taxiShareJoinRequest.getMemberId()).thenReturn(123L);
+        
+        // Call static method with type 1
+        Notification notification = TaxiShareJoinAction.getTaxiShareJoinNotiInfo(
+            taxiShareResponse, taxiShareJoinRequest, participantInfo, hostInfo, 1);
+        
+        assertNotNull(notification);
+        // 기본 설정 검증
+        assertEquals("택시 공유 서비스", notification.getServiceCtg());
+        assertEquals(42L, notification.getSenderId());
+        assertNotNull(notification.getCreatedDate());
+        
+        // 참여 알림 내용: type 1 → 수신자: taxiShareJoinRequest.getMemberId()
+        String expectedContent = "호스트 HostNick님의 택시 공유에 참여하셨습니다! 출발시간: 10:00 AM, 출발지: LocationA, 도착지: DestinationB" +
+            "\n오픈카톡방에 접속하셔서 의사소통해보세요!" +
+            "\n오픈카톡 url: http://openchat.link, 오픈카톡코드: OC123";
+        assertEquals(expectedContent, notification.getContent());
+        assertEquals("신청완료", notification.getCategory());
+        assertEquals(123L, notification.getRecipientId());
+    }
+    
+    // 테스트: 참여 알림 (type == 2, 호스트에게 보낼 알림)
+    @Test
+    void testGetTaxiShareJoinNotiInfo_Type2() {
+        // Stubbing for hostInfo and participantInfo
+        when(hostInfo.getNickname()).thenReturn("HostNick");
+        when(participantInfo.getNickname()).thenReturn("PartiNick");
+        // taxiShareResponse.getMemberId() will be used as recipient for host notification
+        when(taxiShareResponse.getMemberId()).thenReturn(555L);
+        
+        // Call static method with type 2
+        Notification notification = TaxiShareJoinAction.getTaxiShareJoinNotiInfo(
+            taxiShareResponse, taxiShareJoinRequest, participantInfo, hostInfo, 2);
+        
+        assertNotNull(notification);
+        assertEquals("택시 공유 서비스", notification.getServiceCtg());
+        assertEquals(42L, notification.getSenderId());
+        assertNotNull(notification.getCreatedDate());
+        
+        String expectedContent = "HostNick님이 개설하신 택시 공유에 참가자가 생겼습니다! 참가자닉네임: PartiNick";
+        assertEquals(expectedContent, notification.getContent());
+        assertEquals("신청알림", notification.getCategory());
+        assertEquals(555L, notification.getRecipientId());
+    }
+    
+    // 테스트: 삭제 알림
+    @Test
+    void testGetTaxiShareDeleteNotiInfo() {
+        // Stubbing for taxiShareResponse
+        when(taxiShareResponse.getPickupLocation()).thenReturn("LocationA");
+        when(taxiShareResponse.getDestination()).thenReturn("DestinationB");
+        when(taxiShareResponse.getPickupTime()).thenReturn(date);
+        when(taxiShareResponse.getPickupTimeOnly()).thenReturn("AM");
+        // taxiShareJoinRequest.getTaxiShareId()는 사용되지 in content, so stubbing is optional
+        
+        // Stubbing for participantInfo
+        when(participantInfo.getNickname()).thenReturn("PartiNick");
+        when(participantInfo.getMemberId()).thenReturn(888L);
+        
+        // Call static method for delete notification
+        Notification notification = TaxiShareJoinAction.getTaxiShareDeleteNotiInfo(
+            taxiShareResponse, taxiShareJoinRequest, participantInfo);
+        
+        assertNotNull(notification);
+        assertEquals("택시 공유 서비스", notification.getServiceCtg());
+        assertEquals(42L, notification.getSenderId());
+        assertNotNull(notification.getCreatedDate());
+        
+        String expectedContent = "PartiNick고객님, 죄송합니다. 참여 신청하신 택시 공유가 호스트에 의해 삭제되었습니다. 다른 택시 공유를 신청해보세요!! \n" +
+            "삭제된 신청정보\n" +
+            " 출발지: LocationA, 도착지: DestinationB, 출발시간: 10:00 AM";
+        assertEquals(expectedContent, notification.getContent());
+        assertEquals("삭제알림", notification.getCategory());
+        assertEquals(888L, notification.getRecipientId());
+    }
+    
+    // 크레딧 차감 메서드는 로직이 구현되어 있지 않으므로, 테스트 대상이 아닙니다.
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[v] 기능 추가
-[] 기능 삭제
-[v] 버그 수정
-[v] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/test/jacoco -> develop
feature/admin/excel-download -> develop

### 변경 사항
- jacoco 의존성 추가
- apache poi 의존성 추가
- CarShareRegiRequestDTO 파일에 ToString 어노테이션 중복 제거
- excel 다운로드 기능 추가
- excel 기능에 맞게 AdminPaymentDTO 수정