### PR TITLE
차량/택시 참여 동시성 문제 해결

### DIFF
--- a/bururung/build.gradle
+++ b/bururung/build.gradle
@@ -108,6 +108,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	compileOnly 'net.minidev:json-smart:2.0'
 	implementation 'org.apache.poi:poi-ooxml:5.2.3'
+	implementation 'org.springframework.retry:spring-retry'
+	
 }
 
 

--- a/bururung/src/main/java/com/hifive/bururung/BururungApplication.java
+++ b/bururung/src/main/java/com/hifive/bururung/BururungApplication.java
@@ -3,10 +3,12 @@ package com.hifive.bururung;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableRetry
 public class BururungApplication extends SpringBootServletInitializer {
 	
 	@Override

--- a/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/repository/CarRegistrationRepository.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/carshare/organizer/repository/CarRegistrationRepository.java
@@ -5,10 +5,14 @@ import java.util.Optional;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.hifive.bururung.domain.carshare.organizer.entity.CarRegistration;
+import com.hifive.bururung.domain.taxi.entity.TaxiShareEntity;
+
+import jakarta.persistence.LockModeType;
 
 public interface CarRegistrationRepository extends JpaRepository<CarRegistration, Long>{
 	Optional<CarRegistration> findByMember_MemberId(Long memberId);
@@ -22,4 +26,7 @@ public interface CarRegistrationRepository extends JpaRepository<CarRegistration
 	@Query("SELECT c.carId FROM CarRegistration c WHERE c.member.memberId = :memberId")
 	Long findCarIdByMemberId(@Param("memberId") Long memberId);
 
+	@Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+	@Query("select c from CarRegistration c where c.carId = :id")
+	Optional<CarRegistration> findByIdWithLock(@Param("id") Long id);
 }

--- a/bururung/src/main/java/com/hifive/bururung/domain/carshare/participant/repository/ServiceRegistrationRepository.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/carshare/participant/repository/ServiceRegistrationRepository.java
@@ -57,4 +57,7 @@ public interface ServiceRegistrationRepository {
 	
 	// 14. 카테고리 별 공유차량 목록 조회
 	List<AllCarListResponse> findByCategoryShareCarList(String category);
+	
+	// 15. 차량 예약 인원 조회
+	int findJoinCountByCarShareRegiId(Long carShareRegiId);
 }

--- a/bururung/src/main/java/com/hifive/bururung/domain/carshare/participant/service/ServiceRegistrationService.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/carshare/participant/service/ServiceRegistrationService.java
@@ -6,9 +6,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.hifive.bururung.domain.carshare.organizer.entity.CarRegistration;
+import com.hifive.bururung.domain.carshare.organizer.repository.CarRegistrationRepository;
 import com.hifive.bururung.domain.carshare.participant.dto.AllCarListResponse;
 import com.hifive.bururung.domain.carshare.participant.dto.AvailableCarShareListResponse;
 import com.hifive.bururung.domain.carshare.participant.dto.CarInformationResponse;
@@ -16,6 +21,8 @@ import com.hifive.bururung.domain.carshare.participant.dto.DriverInformationResp
 import com.hifive.bururung.domain.carshare.participant.dto.DrivingInformationResponse;
 import com.hifive.bururung.domain.carshare.participant.dto.PastParticipationListResponse;
 import com.hifive.bururung.domain.carshare.participant.repository.ServiceRegistrationRepository;
+import com.hifive.bururung.global.exception.CustomException;
+import com.hifive.bururung.global.exception.errorcode.CarRegistrationErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class ServiceRegistrationService implements IServiceRegistrationService{
 	
 	private final ServiceRegistrationRepository serviceRegistrationRepository;
+	private final CarRegistrationRepository carRegistrationRepository;
 	
 	// 1. 현재 이용 가능한 공유 차량 목록
 	@Override
@@ -54,21 +62,35 @@ public class ServiceRegistrationService implements IServiceRegistrationService{
 	}
 
 	// 5. 공유 차량 예약
-	@Override
-	public boolean insertRegistration(Long carShareRegiId, Long userId) {
-		long leftoverCredit = serviceRegistrationRepository.findLeftoverCredit(userId);
-		
-		if(leftoverCredit >= 7) {
-			Map<String, Object> params = new HashMap<>();
-            params.put("carShareRegiId", carShareRegiId);
-            params.put("userId", userId);
-            
-            serviceRegistrationRepository.insertRegistration(params);
-            return true;
-		} else {
-			return false;
+		@Retryable(
+				retryFor = {ObjectOptimisticLockingFailureException.class },
+				maxAttempts = 3,
+				backoff = @Backoff(delay = 100)
+		)
+		@Override
+		@Transactional
+		public boolean insertRegistration(Long carShareRegiId, Long userId) {
+			CarRegistration carRegistration = carRegistrationRepository.findByIdWithLock(carShareRegiId)
+			.orElseThrow(() -> new CustomException(CarRegistrationErrorCode.CAR_NOT_FOUND));
+			
+			long leftoverCredit = serviceRegistrationRepository.findLeftoverCredit(userId);
+			int joinCount = serviceRegistrationRepository.findJoinCountByCarShareRegiId(carShareRegiId);
+			
+			if(joinCount >= carRegistration.getMaxPassengers()) {
+				throw new CustomException(CarRegistrationErrorCode.FULL_CAPACITY);
+			}
+			
+			if(leftoverCredit >= 7) {
+				Map<String, Object> params = new HashMap<>();
+	            params.put("carShareRegiId", carShareRegiId);
+	            params.put("userId", userId);
+	            
+	            serviceRegistrationRepository.insertRegistration(params);
+	            return true;
+			} else {
+				return false;
+			}
 		}
-	}
 	
 	// 6. 리뷰 평점 조회
 	@Override

--- a/bururung/src/main/java/com/hifive/bururung/domain/taxi/controller/TaxiShareJoinController.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/taxi/controller/TaxiShareJoinController.java
@@ -44,6 +44,48 @@ public class TaxiShareJoinController {
 		return ResponseEntity.ok(taxiShareJoinService.getJoinCountByTaxiShareId(taxiShareId));
 	}
 
+//	// 참여
+//	@PostMapping("/insert")
+//	public ResponseEntity<Void> insertTaxiShareJoin(@RequestBody TaxiShareJoinRequest taxiShareJoinRequest) {
+//		// 이미 참여한 택시인지 확인
+//		int duplCnt = taxiShareJoinService.getDuplCntByTaxiShareIdAndMemberId(taxiShareJoinRequest);
+//		// 내가 호스트인지 확인
+//		int isHost = taxiShareService.getCountTaxsiShareByIdAndMemberId(taxiShareJoinRequest);
+//		// 해당 택시 정보
+//		TaxiShareResponse taxiSahreResponse = taxiShareService.getTaxiShareById(taxiShareJoinRequest.getTaxiShareId());
+//		// 호스트 멤버 정보
+//		Member hostInfo = memberService.findByMemberId(taxiShareJoinRequest.getMemberId());
+//		// 참여자 멤버 정보
+//		Member participantInfo = memberService.findByMemberId(taxiShareJoinRequest.getMemberId());
+//		if (duplCnt < 1) { // 참여한 적이 없으면
+//			if (isHost < 1) { // 호스트가 아니면
+//				// 크레딧 차감
+//				taxiShareJoinService.insertCreditByTaxi(2, taxiShareJoinRequest.getMemberId());
+//				// 알림 보내기
+//				// 참여자에게 보내기 => type=1
+//				Notification notification2Participant = TaxiShareJoinAction.getTaxiShareJoinNotiInfo(taxiSahreResponse,
+//						taxiShareJoinRequest, participantInfo,hostInfo, 1);
+////				System.out.println(notification2Participant.toString());
+//				notificationService.sendNotification(notification2Participant);
+//				// 호스트에게 보내기=> type=2
+//				Notification notification2Host = TaxiShareJoinAction.getTaxiShareJoinNotiInfo(taxiSahreResponse,
+//						taxiShareJoinRequest, participantInfo,hostInfo, 2);
+////				System.out.println(notification2Host.toString());
+//				notificationService.sendNotification(notification2Host);
+//				// 택시 조인 insert(참여)
+//				taxiShareJoinService.insertTaxiShareJoin(taxiShareJoinRequest);
+//				
+//				return ResponseEntity.status(HttpStatus.CREATED).build();
+//			} else {
+////				System.out.println("본인이 호스트인 방엔 참여할 수 없음!!");
+//				throw new CustomException(TaxiShareJoinErrorCode.CANNOT_JOIN_OWN_SHARE);
+//			}
+//		} else {
+////			System.out.println("한사람이 똑같은 방에 참여할 수 없음!!!");
+//			throw new CustomException(TaxiShareJoinErrorCode.DUPLICATE_JOIN_ATTEMPT);
+//		}
+//	}
+	
 	// 참여
 	@PostMapping("/insert")
 	public ResponseEntity<Void> insertTaxiShareJoin(@RequestBody TaxiShareJoinRequest taxiShareJoinRequest) {
@@ -59,29 +101,28 @@ public class TaxiShareJoinController {
 		Member participantInfo = memberService.findByMemberId(taxiShareJoinRequest.getMemberId());
 		if (duplCnt < 1) { // 참여한 적이 없으면
 			if (isHost < 1) { // 호스트가 아니면
-				// 크레딧 차감
-				taxiShareJoinService.insertCreditByTaxi(2, taxiShareJoinRequest.getMemberId());
+				
+				taxiShareJoinService.join(taxiShareJoinRequest);
+
 				// 알림 보내기
 				// 참여자에게 보내기 => type=1
 				Notification notification2Participant = TaxiShareJoinAction.getTaxiShareJoinNotiInfo(taxiSahreResponse,
 						taxiShareJoinRequest, participantInfo,hostInfo, 1);
-//				System.out.println(notification2Participant.toString());
+				System.out.println(notification2Participant.toString());
 				notificationService.sendNotification(notification2Participant);
 				// 호스트에게 보내기=> type=2
 				Notification notification2Host = TaxiShareJoinAction.getTaxiShareJoinNotiInfo(taxiSahreResponse,
 						taxiShareJoinRequest, participantInfo,hostInfo, 2);
-//				System.out.println(notification2Host.toString());
+				System.out.println(notification2Host.toString());
 				notificationService.sendNotification(notification2Host);
-				// 택시 조인 insert(참여)
-				taxiShareJoinService.insertTaxiShareJoin(taxiShareJoinRequest);
 				
 				return ResponseEntity.status(HttpStatus.CREATED).build();
 			} else {
-//				System.out.println("본인이 호스트인 방엔 참여할 수 없음!!");
+				System.out.println("본인이 호스트인 방엔 참여할 수 없음!!");
 				throw new CustomException(TaxiShareJoinErrorCode.CANNOT_JOIN_OWN_SHARE);
 			}
 		} else {
-//			System.out.println("한사람이 똑같은 방에 참여할 수 없음!!!");
+			System.out.println("한사람이 똑같은 방에 참여할 수 없음!!!");
 			throw new CustomException(TaxiShareJoinErrorCode.DUPLICATE_JOIN_ATTEMPT);
 		}
 	}

--- a/bururung/src/main/java/com/hifive/bururung/domain/taxi/entity/TaxiShareEntity.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/taxi/entity/TaxiShareEntity.java
@@ -1,0 +1,76 @@
+package com.hifive.bururung.domain.taxi.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import com.hifive.bururung.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "TAXI_SHARE")
+public class TaxiShareEntity {
+	
+	@Id
+	@SequenceGenerator(
+			name = "TAXI_SHARE_SEQ_GEN",
+			sequenceName = "TAXI_SHARE_SEQ",
+			allocationSize = 1
+	)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "TAXI_SHARE_SEQ_GEN")
+	private Long taxiShareId;
+	
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+	private Member member;
+    
+	private Integer passengersNum;
+	
+	private String pickupLocation;
+	
+	@Column(name = "LATITUDE_PL")
+	private Double latitudePL;
+	
+	@Column(name = "LONGITUDE_PL")
+	private Double longitudePL;
+	
+	private Character status;
+	
+	private LocalDateTime createdDate;
+	
+	private String destination;
+	
+	@Column(name = "LATITUDE_DS")
+	private Double latitudeDS;
+	
+	@Column(name = "LONGITUDE_DS")
+	private Double longitudeDS;
+	
+	private String openchatLink;
+	
+	private String openchatCode;
+	
+	private Integer estimatedAmount;
+	
+	private String timeNego;
+	
+	@Version
+	private Integer version;
+	
+}

--- a/bururung/src/main/java/com/hifive/bururung/domain/taxi/repository/TaxiShareRepository.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/taxi/repository/TaxiShareRepository.java
@@ -1,0 +1,19 @@
+package com.hifive.bururung.domain.taxi.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.hifive.bururung.domain.taxi.entity.TaxiShareEntity;
+
+import jakarta.persistence.LockModeType;
+
+public interface TaxiShareRepository extends JpaRepository<TaxiShareEntity, Long>{
+	
+	@Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+	@Query("select t from TaxiShareEntity t where t.taxiShareId = :id")
+	Optional<TaxiShareEntity> findByIdWithLock(@Param("id") Long id);
+}

--- a/bururung/src/main/java/com/hifive/bururung/domain/taxi/service/ITaxiShareJoinService.java
+++ b/bururung/src/main/java/com/hifive/bururung/domain/taxi/service/ITaxiShareJoinService.java
@@ -17,4 +17,5 @@ public interface ITaxiShareJoinService {
 	int findLeftoverCredit(Long memberId);
 	List<TaxiShareJoinResponse> getTaxiShareByMemberIdOnToday(Long memberId);
 	List<HashMap<String, Object>> getCarShareCountByMemberIdAndSysdate();
+	void join(TaxiShareJoinRequest taxiShareJoinRequest);
 }

--- a/bururung/src/main/java/com/hifive/bururung/global/common/TokenProvider.java
+++ b/bururung/src/main/java/com/hifive/bururung/global/common/TokenProvider.java
@@ -63,9 +63,15 @@ public class TokenProvider implements InitializingBean{
     }
 	
 	public String createRefreshToken(Authentication authentication) {
+        String roleName = authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElse("USER");
         long now = (new Date()).getTime();
         
         return Jwts.builder()
+        		.subject(authentication.getName())
+        		.claim("ROLE_NAME", roleName)
                 .signWith(key)
                 .expiration(new Date(now + refreshTokenValidity * 1000))
                 .compact();

--- a/bururung/src/main/java/com/hifive/bururung/global/exception/errorcode/CarRegistrationErrorCode.java
+++ b/bururung/src/main/java/com/hifive/bururung/global/exception/errorcode/CarRegistrationErrorCode.java
@@ -12,6 +12,7 @@ public enum CarRegistrationErrorCode implements ErrorCode {
     // ✅ 차량 관련 오류
     CAR_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 차량이 없습니다."),
     CAR_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 등록된 차량이 있습니다."),
+    FULL_CAPACITY(HttpStatus.BAD_REQUEST, "차량 공유 정원이 이미 다 찼습니다"),
     
     // ✅ 권한 관련 오류
     ROLE_NOT_MODIFY(HttpStatus.FORBIDDEN, "차량 정보 수정 권한이 없습니다."),

--- a/bururung/src/main/resources/mapper/carshare/participant/CarshareRegistrationMapper.xml
+++ b/bururung/src/main/resources/mapper/carshare/participant/CarshareRegistrationMapper.xml
@@ -156,4 +156,11 @@ WHERE csj.member_id = #{userId}
             	)
             AND category = #{category}
 	</select>
+	
+	<!-- 15. 차량 예약 인원 조회 -->
+	<select id="findJoinCountByCarShareRegiId" resultType="int">
+		select NVL(COUNT(member_id), 0) AS CNT
+		from car_share_join
+		where car_share_regi_id = #{param1}
+	</select>
 </mapper>

--- a/bururung/src/main/resources/mapper/taxi/TaxiShareJoinMapper.xml
+++ b/bururung/src/main/resources/mapper/taxi/TaxiShareJoinMapper.xml
@@ -3,12 +3,10 @@
 <mapper
 	namespace="com.hifive.bururung.domain.taxi.repository.ITaxiShareJoinRepository">
 	<select id="getJoinCountByTaxiShareId" resultType="int">
-		select
-		count(member_id) AS CNT
+		select NVL(COUNT(member_id), 0) AS CNT
 		from taxi_share_join
 		where taxi_share_id =
 		#{param1}
-		group by taxi_share_id
 	</select>
 
 	<insert id="insertTaxiShareJoin"

--- a/bururung/src/test/java/com/hifive/bururung/domain/carshare/participant/controller/ServiceRegistrationControllerTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/carshare/participant/controller/ServiceRegistrationControllerTest.java
@@ -455,7 +455,7 @@ public class ServiceRegistrationControllerTest {
     void testFindPastParticipationList_Success() {
         Long userId = 1L;
         PastParticipationListResponse pastResponse = pastParticipationListResponse;
-        when(registrationService.findPastParticipationList(userId)).thenReturn(pastResponse);
+        when(registrationService.findPastParticipationList(userId)).thenReturn((List<PastParticipationListResponse>) pastResponse);
 
         ResponseEntity<Object> response = controller.findPastParticipationList(userId);
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/bururung/src/test/java/com/hifive/bururung/domain/carshare/participant/service/ServiceRegistrationServiceTest.java
+++ b/bururung/src/test/java/com/hifive/bururung/domain/carshare/participant/service/ServiceRegistrationServiceTest.java
@@ -192,9 +192,9 @@ public class ServiceRegistrationServiceTest {
     void testFindPastParticipationList() {
         Long userId = 1L;
         PastParticipationListResponse pastResponse = pastParticipationListResponse;
-        when(repository.findPastParticipationList(userId)).thenReturn(pastResponse);
+        when(repository.findPastParticipationList(userId)).thenReturn((List<PastParticipationListResponse>) pastResponse);
 
-        PastParticipationListResponse result = service.findPastParticipationList(userId);
+        PastParticipationListResponse result = (PastParticipationListResponse) service.findPastParticipationList(userId);
         assertEquals(pastResponse, result);
         verify(repository).findPastParticipationList(userId);
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[v] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/optimistic-lock -> develop

### 변경 사항
- 차량/택시 참여에 낙관적 락을 통해 동시성 문제를 해결함
- Spring Retry를 이용해 낙관적 락 예외 발생시 일정 횟수 재시도 하도록 구현

### 테스트 결과
<img width="1116" alt="동시성" src="https://github.com/user-attachments/assets/3de69641-9a7b-43a8-9a33-b04661b01713" />
- 정원이 2명인 방에 쓰레드를 3개 생성해서 동시에 참여하도록 한 결과 2명만 성공하는 것을 확인
